### PR TITLE
guard against missing `document` on React Native

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ function makeQuery(options) {
         query.config.retry === true ||
         query.state.failureCount < query.config.retry
       ) {
-        if (!isDocumentVisible()) {
+        if (typeof document !== 'undefined' && !isDocumentVisible()) {
           return new Promise(r => {})
         }
 


### PR DESCRIPTION
Fixes https://github.com/tannerlinsley/react-query/issues/39