### PR TITLE
Fix prefetchQuery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This library is being built and maintained by me, @tannerlinsley and I am always
   - [`useMutation`](#usemutation)
   - [`setQueryData`](#setquerydata)
   - [`refetchQuery`](#refetchquery)
-  - [`prefetchQuery`](#prefetchQuery)
+  - [`prefetchQuery`](#prefetchquery)
   - [`refetchAllQueries`](#refetchallqueries)
   - [`useIsFetching`](#useisfetching)
   - [`clearQueryCache`](#clearquerycache)


### PR DESCRIPTION
The prefetchQuery link was not working due to it being camel cased instead of lower case.  This will fix that and make the link work again!