### PR TITLE
Update useMutation memoization

### DIFF
--- a/src/useMutation.js
+++ b/src/useMutation.js
@@ -67,9 +67,6 @@ export function useMutation(
 
   const mutate = React.useCallback(
     async (variables, options = {}) => {
-      if (![statusIdle, statusSuccess, statusError].includes(state.status)) {
-        return
-      }
       dispatch({ type: actionMutate })
 
       const resolvedOptions = {
@@ -95,7 +92,7 @@ export function useMutation(
         }
       }
     },
-    [getConfig, getMutationFn, state.status]
+    [getConfig, getMutationFn]
   )
 
   const reset = React.useCallback(() => dispatch({ type: actionReset }), [])

--- a/src/useMutation.js
+++ b/src/useMutation.js
@@ -64,9 +64,15 @@ export function useMutation(
     ...useConfigContext(),
     ...config,
   })
+  
+  const getStatus = useGetLatest(state.status)
 
   const mutate = React.useCallback(
     async (variables, options = {}) => {
+      if (![statusIdle, statusSuccess, statusError].includes(getStatus())) {
+        return
+      }
+      
       dispatch({ type: actionMutate })
 
       const resolvedOptions = {
@@ -92,7 +98,7 @@ export function useMutation(
         }
       }
     },
-    [getConfig, getMutationFn]
+    [getConfig, getMutationFn, getStatus]
   )
 
   const reset = React.useCallback(() => dispatch({ type: actionReset }), [])


### PR DESCRIPTION
This will fix the issue identified here https://github.com/tannerlinsley/react-query/issues/165, however I am not sure if the check on the status in the useCallback was needed for a particular reason?

This will allow the mutation function to safely be included in a dependency array of an effect, like below.
```javascript
const [mutate]  = useMutation(SOME_MUTATION);
React.useEffect(() => {
  mutate();
}, [mutate]);
```