### PR TITLE
Test garbage collection of queries without data

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -263,11 +263,8 @@ describe('useQuery', () => {
 
     expect(Object.keys(queryCache.queries).length).toEqual(5)
 
-    // wait for garbage collection
-    await sleep(0)
+    await waitForElement(() => rendered.getByText('todo aaaa'))
 
     expect(Object.keys(queryCache.queries).length).toEqual(1)
-
-    await waitForElement(() => rendered.getByText('todo aaaa'))
   })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -1,4 +1,4 @@
-import { cleanup, render, act, waitForElement } from '@testing-library/react'
+import { cleanup, render, act, waitForElement, fireEvent } from '@testing-library/react'
 import * as React from 'react'
 
 import { useQuery, queryCache, statusLoading, statusSuccess } from '../index'
@@ -225,5 +225,40 @@ describe('useQuery', () => {
     await waitForElement(() => rendered.getByText('Failed 2 times'))
 
     expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should garbage collect queries without data immediately', async () => {
+    function Page() {
+      const [filter, setFilter] = React.useState('');
+      const { data } = useQuery(['todos', { filter }], async (key, { filter } = {}) => {
+        await sleep(1000);
+        return `todo ${filter}`;
+      })
+
+      return (
+        <div>
+          <div>{data}</div>
+          <button onClick={() => setFilter(filter + 'a')}>update</button>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitForElement(() => rendered.getByText('update'))
+
+    fireEvent.click(rendered.getByText('update'))
+    fireEvent.click(rendered.getByText('update'))
+    fireEvent.click(rendered.getByText('update'))
+    fireEvent.click(rendered.getByText('update'))
+
+    expect(Object.keys(queryCache.queries).length).toEqual(5)
+
+    // wait for garbage collection
+    await sleep(0)
+
+    expect(Object.keys(queryCache.queries).length).toEqual(1)
+
+    await waitForElement(() => rendered.getByText('todo aaaa'));
   })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -1,4 +1,10 @@
-import { cleanup, render, act, waitForElement, fireEvent } from '@testing-library/react'
+import {
+  cleanup,
+  render,
+  act,
+  waitForElement,
+  fireEvent,
+} from '@testing-library/react'
 import * as React from 'react'
 
 import { useQuery, queryCache, statusLoading, statusSuccess } from '../index'
@@ -229,11 +235,14 @@ describe('useQuery', () => {
 
   it('should garbage collect queries without data immediately', async () => {
     function Page() {
-      const [filter, setFilter] = React.useState('');
-      const { data } = useQuery(['todos', { filter }], async (key, { filter } = {}) => {
-        await sleep(1000);
-        return `todo ${filter}`;
-      })
+      const [filter, setFilter] = React.useState('')
+      const { data } = useQuery(
+        ['todos', { filter }],
+        async (key, { filter } = {}) => {
+          await sleep(1000)
+          return `todo ${filter}`
+        }
+      )
 
       return (
         <div>
@@ -259,6 +268,6 @@ describe('useQuery', () => {
 
     expect(Object.keys(queryCache.queries).length).toEqual(1)
 
-    await waitForElement(() => rendered.getByText('todo aaaa'));
+    await waitForElement(() => rendered.getByText('todo aaaa'))
   })
 })


### PR DESCRIPTION
Tests this piece of code:
https://github.com/tannerlinsley/react-query/blob/213df4a4fd87b705789c09d6eb63491e6c7b74c7/src/queryCache.js#L209-L219

Test fails, when cache timeout is set to `query.config.cacheTime`, i.e.:

```diff
 query.scheduleGarbageCollection = () => { 
   query.cacheTimeout = setTimeout( 
     () => { 
       cache.removeQueries(d => d.queryHash === query.queryHash) 
     }, 
-     typeof query.state.data === 'undefined' && 
-       query.state.status !== 'error' 
-       ? 0 
-       : query.config.cacheTime
+      query.config.cacheTime 
   ) 
 } 
```