### PR TITLE
Add missing axios dependency used by queries.js

### DIFF
--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -5,6 +5,7 @@
   "keywords": [],
   "main": "src/index.js",
   "dependencies": {
+    "axios": "0.19.2",
     "react": "0.0.0-experimental-5faf377df",
     "react-dom": "0.0.0-experimental-5faf377df",
     "react-query": "latest",


### PR DESCRIPTION
Csb reports missing dependency when trying to run.
![image](https://user-images.githubusercontent.com/11829847/75645050-84fd0d80-5c7f-11ea-8074-8d77cc3c7ef5.png)
