### PR TITLE
queryCache.prefetchQuery should return cache contents on cache hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2164,7 +2164,7 @@ The options for `prefetchQuery` are exactly the same as those of [`useQuery`](#u
 ### Returns
 
 - `promise: Promise`
-  - A promise is returned that will either resolve with the **query's response data**. It **will not** throw an error if the prefetch fails, but this can be configured by setting the `throwOnError` option to `true`
+  - A promise is returned that will either immediately resolve with the query's cached response data, or resolve to the data returned by the fetch function. It **will not** throw an error if the fetch fails. This can be configured by setting the `throwOnError` option to `true`.
 
 ## `queryCache.getQueryData`
 

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -167,9 +167,9 @@ export function makeQueryCache() {
           throw err
         }
       }
-    } else {
-      return Promise.resolve(query.state.data)
     }
+    
+    return query.state.data
   }
 
   cache.setQueryData = (queryKey, updater, { exact } = {}) => {

--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -167,6 +167,8 @@ export function makeQueryCache() {
           throw err
         }
       }
+    } else {
+      return Promise.resolve(query.state.data)
     }
   }
 

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -9,4 +9,12 @@ describe('queryCache', () => {
       }))
     ).not.toThrow()
   })
+
+  test('setQueryData does not crash if query could not be found', async () => {
+    const fetchFn = () => Promise.resolve('data')
+    const first = await queryCache.prefetchQuery('key', fetchFn)
+    const second = await queryCache.prefetchQuery('key', fetchFn)
+
+    expect(second).toBe(first)
+  })
 })

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -10,7 +10,7 @@ describe('queryCache', () => {
     ).not.toThrow()
   })
 
-  test('setQueryData does not crash if query could not be found', async () => {
+  test('prefetchQuery returns the cached data on cache hits', async () => {
     const fetchFn = () => Promise.resolve('data')
     const first = await queryCache.prefetchQuery('key', fetchFn)
     const second = await queryCache.prefetchQuery('key', fetchFn)


### PR DESCRIPTION
Hey Tanner,

currently queryCache.prefetchQuery only explicitly returns if a fetch was actually attempted, due to `query.state.isStale || force`. This leads to it returning `undefined` for cache hits.

This PR naively fixes my failing test, let me know if there's more to be considered here.

codesandbox repro https://codesandbox.io/s/react-query-bug-repro-gi7oy