### PR TITLE
fix queryCache not notifying listeners, when query with initialData is added

### DIFF
--- a/src/queryCache.js
+++ b/src/queryCache.js
@@ -133,6 +133,7 @@ export function makeQueryCache() {
       if (query.queryHash) {
         if (!isServer) {
           cache.queries[queryHash] = query
+          notifyGlobalListeners()
         }
       }
     }

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -30,4 +30,15 @@ describe('queryCache', () => {
     queryCache.prefetchQuery('test', () => 'data')
 
     expect(callback).toHaveBeenCalled()
+  })
+
+  test('should notify subsribers when new query with initialData is added', () => {
+    const callback = jest.fn();
+
+    queryCache.subscribe(callback)
+
+    queryCache.prefetchQuery('test', () => {}, { initialData: 'initial' })
+
+    expect(callback).toHaveBeenCalled()
+  })
 })

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -23,7 +23,7 @@ describe('queryCache', () => {
   })
 
   test('should notify listeners when new query is added', () => {
-    const callback = jest.fn();
+    const callback = jest.fn()
 
     queryCache.subscribe(callback)
 
@@ -33,7 +33,7 @@ describe('queryCache', () => {
   })
 
   test('should notify subsribers when new query with initialData is added', () => {
-    const callback = jest.fn();
+    const callback = jest.fn()
 
     queryCache.subscribe(callback)
 

--- a/src/tests/queryCache.test.js
+++ b/src/tests/queryCache.test.js
@@ -1,6 +1,10 @@
 import { queryCache } from '../index'
 
 describe('queryCache', () => {
+  afterEach(() => {
+    queryCache.clear();
+  })
+
   test('setQueryData does not crash if query could not be found', () => {
     expect(() =>
       queryCache.setQueryData(['USER', { userId: 1 }], prevUser => ({
@@ -17,4 +21,13 @@ describe('queryCache', () => {
 
     expect(second).toBe(first)
   })
+
+  test('should notify listeners when new query is added', () => {
+    const callback = jest.fn();
+
+    queryCache.subscribe(callback)
+
+    queryCache.prefetchQuery('test', () => 'data')
+
+    expect(callback).toHaveBeenCalled()
 })


### PR DESCRIPTION
Turns out, that when query with initialData is added, `notifyGlobalListeners` is never called, since `dispatch` is never called.