### PR TITLE
Fix useQuery infinite loop after query key is changed to falsy

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -107,7 +107,9 @@ describe('useQuery', () => {
     const { getByTestId } = render(<Page />)
 
     await waitForElement(() => getByTestId('status'))
-    expect(getByTestId('status').textContent).toBe('loading')
+    act(() => {
+      expect(getByTestId('status').textContent).toBe('loading')
+    })
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/144

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -527,6 +527,7 @@ describe('useQuery', () => {
     expect(rendered.getByTestId('status').textContent).toBe('success')
   })
 
+  // See https://github.com/tannerlinsley/react-query/issues/214
   it('should not cause infinite loop after query key is changed to falsy', async () => {
     const callback = jest.fn()
 

--- a/src/useBaseQuery.js
+++ b/src/useBaseQuery.js
@@ -21,7 +21,28 @@ export function useBaseQuery(queryKey, queryVariables, queryFn, config = {}) {
     ...config,
   }
 
-  let query = queryCache._buildQuery(queryKey, queryVariables, queryFn, config)
+  const queryRef = React.useRef()
+
+  const newQuery = queryCache._buildQuery(
+    queryKey,
+    queryVariables,
+    queryFn,
+    config
+  )
+
+  const prevQuery = queryRef.current
+  if (
+    prevQuery &&
+    typeof prevQuery.queryHash === 'undefined' &&
+    typeof newQuery.queryHash === 'undefined'
+  ) {
+    // Do not use new query with undefined queryHash, if previous query also had undefined queryHash.
+    // Otherwise this will cause infinite loop.
+  } else {
+    queryRef.current = newQuery
+  }
+
+  const query = queryRef.current
 
   const [, rerender] = React.useState()
   const getLatestConfig = useGetLatest(config)


### PR DESCRIPTION
Fixes #214 

I don't like test implementation, but I didn't find another way to test infinite loop.
Also, it logs `test was not wrapped in act(...)` warning, but I had no luck avoiding it.