### PR TITLE
Fix type error when a null query key is used

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -89,6 +89,27 @@ describe('useQuery', () => {
     await waitForElement(() => rendered.getByText('Second Status: success'))
   })
 
+  // See https://github.com/tannerlinsley/react-query/issues/217
+  it('should start with status success if a null query key is supplied', async () => {
+    function Page() {
+      const first = useQuery(null && 'first', () => 'data')
+      const second = useQuery('second', () => 'data')
+
+      return (
+        <div>
+          <div>First Status: {first.status}</div>
+          <div>Second Status: {second.status}</div>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    rendered.getByText('First Status: success')
+    await waitForElement(() => rendered.getByText('Second Status: loading'))
+    await waitForElement(() => rendered.getByText('Second Status: success'))
+  })
+
   // See https://github.com/tannerlinsley/react-query/issues/144
   it('should be in "loading" state by default', async () => {
     function Page() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,7 +88,7 @@ export function isOnline() {
 }
 
 export function getQueryArgs(args) {
-  if (typeof args[0] === 'object' && args[0].queryKey) {
+  if (isObject(args[0]) && args[0].queryKey) {
     const { queryKey, variables = [], queryFn, config = {} } = args[0]
     return [queryKey, variables, queryFn, config]
   }


### PR DESCRIPTION
Fixes #217 

Use the already provided `isObject` to not accept `null` as a valid `object`.

I also added a test to run over this behavior.