### PR TITLE
test(useQuery): Ensure we await the rendered text we expect

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -1,9 +1,4 @@
-import {
-  render,
-  act,
-  waitForElement,
-  fireEvent,
-} from '@testing-library/react'
+import { render, act, waitForElement, fireEvent } from '@testing-library/react'
 import * as React from 'react'
 
 import { useQuery, queryCache } from '../index'
@@ -152,9 +147,9 @@ describe('useQuery', () => {
       )
     }
 
-    const rendered = render(<Page />)
+    const { findByText } = render(<Page />)
 
-    rendered.getByText('success')
+    await findByText('success')
   })
 
   // See https://github.com/tannerlinsley/react-query/issues/147


### PR DESCRIPTION
I noticed that CI was failing intermittently on a test and it was receiving an `act()` warning. I believe it's because we should be awaiting the find of the text to allow for async work to happen in `useQuery`.

To reproduce locally, run `yarn test` then `a` for all tests, then hit `Enter` twice to do two full test runs in sequence. The subsequent runs should fail reliably on this test.

This seemed to be introduced after my PR #332 perhaps due to fixing the GC issue, and a state update happening that isn't waited for during the test. Other tests do use `act` to do assertions as well, plus using `find` for components that do async work seems a lot more reliable.

## Changes

- Fix `act` warning that happens on subsequent test runs for test `should be in "success" state by default in manual mode`