### PR TITLE
minor: fix instruction typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,7 @@ function App() {
 Query configuration:
 
 ```js
-const { useQuery } from 'react-query'
+import { useQuery } from 'react-query'
 
 // Enable for an individual query
 useQuery(queryKey, queryFn, { suspense: true })


### PR DESCRIPTION
AFAIK this isn't an acceptable way to import (my editor was complaining)

```
const { useQuery } from 'react-query'
```