### PR TITLE
Update @scarf/scarf version to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "dependencies": {
-    "@scarf/scarf": "^0.1.3"
+    "@scarf/scarf": "^1.0.0"
   },
   "peerDependencies": {
     "react": "^16.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,10 +1827,10 @@
   dependencies:
     estree-walker "^1.0.1"
 
-"@scarf/scarf@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-0.1.3.tgz#536f4fe54c613fca20f84dc7700ed3b8f1fb73cf"
-  integrity sha512-ftMyZO7Mi8JQh8XLBcuH3erPGmT4CU4s131nsZIDC7/PYXxaDCJtOzbz3okH0YiTAif+DSIlFhX6d7FXLOtnvA==
+"@scarf/scarf@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.0.tgz#109fc9c723bac288b92b98a23d178ec21001a961"
+  integrity sha512-uzjTaPmtzBLHkOrx97FKJWXeb0xzx/lOrljh7OvBNFgJM7MFS8OwO3w1CTiDNjbvtHzN4m+5DzscmNN5CxM9Og==
 
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
This change bumps the version of Scarf, to ensure react-query continues to use the latest version of the package. 