### PR TITLE
types: add retry function to query options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -377,10 +377,11 @@ export interface BaseQueryOptions {
   manual?: boolean
   /**
    * If `false`, failed queries will not retry by default.
-   * If `true`, failed queries will retry infinitely.
+   * If `true`, failed queries will retry infinitely., failureCount: num
    * If set to an integer number, e.g. 3, failed queries will retry until the failed query count meets that number.
+   * If set to a function `(failureCount, error) => boolean` failed queries will retry until the function returns false.
    */
-  retry?: boolean | number
+  retry?: boolean | number | ((failureCount: number, error: unknown) => boolean)
   retryDelay?: (retryAttempt: number) => number
   staleTime?: number
   cacheTime?: number


### PR DESCRIPTION
This adds `retry` as a function to the types, so it matches the documentation.

https://github.com/tannerlinsley/react-query#retries