### PR TITLE
Update CachedQuery to add type to state member

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -566,12 +566,23 @@ export type MutationResult<TResult> =
   | ErrorMutationResult<TResult>
   | SuccessMutationResult<TResult>
 
-export interface CachedQuery {
+export interface CachedQueryState<T> {
+  data?: T
+  error?: unknown | null
+  failureCount: number
+  isFetching: boolean
+  canFetchMore?: boolean
+  isStale: boolean
+  status: 'loading' | 'error' | 'success'
+  updatedAt: number
+}
+
+export interface CachedQuery<T> {
   queryKey: AnyQueryKey
   queryVariables: AnyVariables
   queryFn: (...args: any[]) => unknown
   config: QueryOptions<unknown>
-  state: unknown
+  state: CachedQueryState<T>
   setData(
     dataOrUpdater: unknown | ((oldData: unknown | undefined) => unknown)
   ): void


### PR DESCRIPTION
While using the `queryCache.refetchQueries` method with a predicate, I noticed that the `query.state` was typed as `unknown`. This blocks retrieval of the `data` member of `state`.

I have added types to the `state` member, `CachedQueryState<T>`. I decided to make it generic in order to be able to constrain the type for `data` - however, it could also be `any` just as easily.

Should this be backported back to DefinitelyTyped?