### PR TITLE
Avoid using externalHelpers in prod

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,14 +10,7 @@
     ],
     "@babel/react"
   ],
-  "plugins": [
-    [
-      "babel-plugin-transform-async-to-promises",
-      {
-        externalHelpers: true
-      }
-    ]
-  ],
+  "plugins": ["babel-plugin-transform-async-to-promises"],
   "env": {
     "test": {
       "presets": [


### PR DESCRIPTION
Fixes https://github.com/tannerlinsley/react-query/issues/567

For some reason, babel doesn't transpile what's output by `babel-plugin-transform-async-to-promises` plugin.

I tried to change babel's config but the only thing I tried that worked was changing this option.
I also looked at the output and it seems to be the same, the only difference I spotted is that instead of having one `_async`, `_await` and `_catch` and `_invoke`, there are 3 in total (`_async$1` etc.), and `_Pact` is defined at the end of the file.

The fact that those functions are defined 3 times only increases the bundle size by 50B (the image shows a difference from my code with prod, thus the -51B instead of +):
![image](https://user-images.githubusercontent.com/22725671/84166324-07624e00-aa75-11ea-9ef4-aab478e7c0c4.png)
