### PR TITLE
fix(types): enable more types for first QueryKey

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -339,17 +339,23 @@ export function useInfiniteQuery<
   config?: InfiniteQueryOptions<TResult, TMoreVariable, TError>
 ): InfiniteQueryResult<TResult, TMoreVariable, TError>
 
+export type DefinedQueryKeyPart = 
+  | string
+  | object
+  | boolean
+  | number
+  | readonly QueryKeyPart[]
+
 export type QueryKeyPart =
   | string
   | object
   | boolean
   | number
-  | null
   | readonly QueryKeyPart[]
   | null
   | undefined
 
-export type AnyQueryKey = readonly [string, ...QueryKeyPart[]] // this forces the key to be inferred as a tuple
+export type AnyQueryKey = readonly [DefinedQueryKeyPart, ...QueryKeyPart[]] // this forces the key to be inferred as a tuple
 
 export type AnyVariables = readonly [] | readonly [any, ...any[]] // this forces the variables to be inferred as a tuple
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -33,9 +33,13 @@ function queryWithVariables() {
   queryVariables.refetch({ force: true }) // $ExpectType Promise<boolean>
 }
 
-function invalidSimpleQuery() {
-  // first element in the key must be a string
-  useQuery([10, 'a'], async (id, key) => id) // $ExpectError
+function queryKeyArrayOrder() {
+  // first element in the key must be not null/undefined
+  useQuery([null, 'a'], async (id, key) => id) // $ExpectError
+
+  useQuery([10, 'a'], async (id, key) => id)
+  useQuery([false, 'a'], async (id, key) => id)
+  useQuery([{ complex: { obj: "yes" } }, 'a'], async (id, key) => id)
 }
 
 function conditionalQuery(condition: boolean) {


### PR DESCRIPTION
This change enables more types beyond just `string` for the first QueryKey but still ensures that it's not `null`/`undefined`.

* The current type is too strict
* The `queryKeySerializerFn` doesn't play well with TypeScript when removing the first key so TypeScript users will benefit from being able to move their string key to the end of the list instead of having to add an additional argument to their functions.

This change will enable the following TypeScript code:

```ts
function doAdd(num: number): Promise<number> {
    return Promise.resolve(num + 1);
}
useQuery<number, [number, string]>([10, "adder"], doAdd);
```

Before this change you'd have to modify your function to accept an additional argument which was unnecessary:

```ts
function doAdd(key: string, num: number): Promise<number>{
    return Promise.resolve(num + 1);
}
useQuery<number, [string, number]>(["adder", 10], doAdd);
```