### PR TITLE
fix(types): change return type of removeQueries

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -705,7 +705,7 @@ export interface QueryCache {
       | string
       | ((query: CachedQuery<unknown>) => boolean),
     { exact }?: { exact?: boolean }
-  ): Promise<void>
+  ): void
   getQuery(queryKey: AnyQueryKey): CachedQuery<unknown> | undefined
   getQueries(queryKey: AnyQueryKey): Array<CachedQuery<unknown>>
   cancelQueries(


### PR DESCRIPTION
Fixed return type of `queryCache.removeQueries`. The function has no return value but was incorrectly labeled as returning a promise.