### PR TITLE
Refetch interval fix

### DIFF
--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -1069,77 +1069,77 @@ describe('useQuery', () => {
   })
 
   it('respects the shortest active refetch interval', async () => {
-      let currentNumber = 0;
-      const fetchNumber = () => {
-        return currentNumber++;
-      }
-  
-      function NumberConsumer1() {
-        const { data: number } = useQuery(
-          ['number'],
-          fetchNumber,
-          { refetchInterval: 300 }
-        );
-        return `consumer 1: ${number}`
-      }
-  
-      function NumberConsumer2() {
-        const { data: number } = useQuery(
-          ['number'],
-          fetchNumber,
-          { refetchInterval: 1000 }
-        );
-        return `consumer 2: ${number}`
-      }
+    let currentNumber = 0;
+    const fetchNumber = () => {
+      return currentNumber++;
+    }
 
-      function Page() {
-        const [consumer1Visible, setConsumer1Visible] = React.useState(true);
-        return (<div>
-          {consumer1Visible && <NumberConsumer1 />}
-          <NumberConsumer2 />
-          <button onClick={() => setConsumer1Visible(false)}>hide consumer 1</button>
-        </div>);
-      }
-
-      const queryConfig = {
-        suspense: true
-      };
-
-      const { container, getByText } = render(
-        <ReactQueryConfigProvider config={queryConfig}>
-          <React.Suspense fallback={"loading"}>
-            <Page />
-          </React.Suspense>
-        </ReactQueryConfigProvider>
+    function NumberConsumer1() {
+      const { data: number } = useQuery(
+        ['number'],
+        fetchNumber,
+        { refetchInterval: 300 }
       );
+      return `consumer 1: ${number}`
+    }
 
-      await waitFor(() => {
-        expect(container.textContent).toMatch(/consumer 1: 0/)
-        expect(container.textContent).toMatch(/consumer 2: 0/)
-      });
+    function NumberConsumer2() {
+      const { data: number } = useQuery(
+        ['number'],
+        fetchNumber,
+        { refetchInterval: 1000 }
+      );
+      return `consumer 2: ${number}`
+    }
 
-      await sleep(301);
+    function Page() {
+      const [consumer1Visible, setConsumer1Visible] = React.useState(true);
+      return (<div>
+        {consumer1Visible && <NumberConsumer1 />}
+        <NumberConsumer2 />
+        <button onClick={() => setConsumer1Visible(false)}>hide consumer 1</button>
+      </div>);
+    }
 
-      expect(container.textContent).toMatch(/consumer 1: 1/)
-      expect(container.textContent).toMatch(/consumer 2: 1/)
+    const queryConfig = {
+      suspense: true
+    };
 
-      await sleep(301);
+    const { container, getByText } = render(
+      <ReactQueryConfigProvider config={queryConfig}>
+        <React.Suspense fallback={"loading"}>
+          <Page />
+        </React.Suspense>
+      </ReactQueryConfigProvider>
+    );
 
-      expect(container.textContent).toMatch(/consumer 1: 2/)
-      expect(container.textContent).toMatch(/consumer 2: 2/)
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/consumer 1: 0/)
+      expect(container.textContent).toMatch(/consumer 2: 0/)
+    });
 
-      fireEvent.click(getByText(/hide consumer 1/))
+    await sleep(301);
 
-      await waitFor(() => {
-        expect(container.textContent).not.toMatch(/consumer 1:/)
-      });
+    expect(container.textContent).toMatch(/consumer 1: 1/)
+    expect(container.textContent).toMatch(/consumer 2: 1/)
 
-      await sleep(301);
-      
-      expect(container.textContent).toMatch(/consumer 2: 2/)
+    await sleep(301);
 
-      await sleep(1500);
+    expect(container.textContent).toMatch(/consumer 1: 2/)
+    expect(container.textContent).toMatch(/consumer 2: 2/)
 
-      expect(container.textContent).toMatch(/consumer 2: 3/)
+    fireEvent.click(getByText(/hide consumer 1/))
+
+    await waitFor(() => {
+      expect(container.textContent).not.toMatch(/consumer 1:/)
+    });
+
+    await sleep(301);
+    
+    expect(container.textContent).toMatch(/consumer 2: 2/)
+
+    await sleep(1500);
+
+    expect(container.textContent).toMatch(/consumer 2: 3/)
   })
 })

--- a/src/tests/useQuery.test.js
+++ b/src/tests/useQuery.test.js
@@ -13,6 +13,7 @@ import {
   useQueryCache,
   makeQueryCache,
   ReactQueryCacheProvider,
+  ReactQueryConfigProvider,
 } from '../index'
 import { sleep } from './utils'
 
@@ -1065,5 +1066,80 @@ describe('useQuery', () => {
     expect(container.firstChild.textContent).toEqual('count: 5')
     await sleep(110);
     expect(container.firstChild.textContent).toEqual('count: 5')
+  })
+
+  it('respects the shortest active refetch interval', async () => {
+      let currentNumber = 0;
+      const fetchNumber = () => {
+        return currentNumber++;
+      }
+  
+      function NumberConsumer1() {
+        const { data: number } = useQuery(
+          ['number'],
+          fetchNumber,
+          { refetchInterval: 300 }
+        );
+        return `consumer 1: ${number}`
+      }
+  
+      function NumberConsumer2() {
+        const { data: number } = useQuery(
+          ['number'],
+          fetchNumber,
+          { refetchInterval: 1000 }
+        );
+        return `consumer 2: ${number}`
+      }
+
+      function Page() {
+        const [consumer1Visible, setConsumer1Visible] = React.useState(true);
+        return (<div>
+          {consumer1Visible && <NumberConsumer1 />}
+          <NumberConsumer2 />
+          <button onClick={() => setConsumer1Visible(false)}>hide consumer 1</button>
+        </div>);
+      }
+
+      const queryConfig = {
+        suspense: true
+      };
+
+      const { container, getByText } = render(
+        <ReactQueryConfigProvider config={queryConfig}>
+          <React.Suspense fallback={"loading"}>
+            <Page />
+          </React.Suspense>
+        </ReactQueryConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(container.textContent).toMatch(/consumer 1: 0/)
+        expect(container.textContent).toMatch(/consumer 2: 0/)
+      });
+
+      await sleep(301);
+
+      expect(container.textContent).toMatch(/consumer 1: 1/)
+      expect(container.textContent).toMatch(/consumer 2: 1/)
+
+      await sleep(301);
+
+      expect(container.textContent).toMatch(/consumer 1: 2/)
+      expect(container.textContent).toMatch(/consumer 2: 2/)
+
+      fireEvent.click(getByText(/hide consumer 1/))
+
+      await waitFor(() => {
+        expect(container.textContent).not.toMatch(/consumer 1:/)
+      });
+
+      await sleep(301);
+      
+      expect(container.textContent).toMatch(/consumer 2: 2/)
+
+      await sleep(1500);
+
+      expect(container.textContent).toMatch(/consumer 2: 3/)
   })
 })


### PR DESCRIPTION
Hi! 👋 

Auto refetching is great! 👍

This PR contains a fix for the timers used to handle auto refetching.

As you can see in the added test case, if 2 components were using the same resource, hiding one of them was breaking auto refetching for the other component.

P.S. I've just seen this PR https://github.com/tannerlinsley/react-query/pull/585 and now I'm not sure if mine makes sense. 😅

Please let me know what do you think.

Cheers! 🙂