### PR TITLE
fix: makeQueryCache config was not optional in the type def

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -385,7 +385,7 @@ export interface BaseQueryOptions<TError = Error> {
   onError?: (err: TError) => void
   onSettled?: (data: any | undefined, error: TError | null) => void
   isDataEqual?: (oldData: unknown, newData: unknown) => boolean,
-  useErrorBoundary: boolean,
+  useErrorBoundary?: boolean,
 }
 
 export interface QueryOptions<TResult, TError = Error>


### PR DESCRIPTION
I'm just trying out v2 while a lot of our code is in a non-release phase (not sure when you plan on fully releasing v2?), so happy to throw any PRs for bits and pieces.

This started as a single quick type fix but it's turned into a general "fix the types" PR...

- The makeQueryCache config should be optional
- Adding the `enabled` option to the query opts
- Updating ReactQueryProviderConfig type to reflect the new 3-part structure
- I've removed the `force` flag from everywhere as it's no longer used
- I've added `idle` to the list of statuses
- I've also exported this as `QueryStatus` as I was often having to manually write `status: 'success' | 'loading' | 'error'` when we're passing the status into other components