### PR TITLE
RFC - define query types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,19 @@
 import * as React from 'react'
 import * as _ from 'ts-toolbelt'
 
+  /**
+   * This allows global typing of React query functions
+   * @example
+   *
+   * declare module 'react-query' {
+   *   export interface QueryTypes {
+   *    todos: TodoItem[]
+   *   }
+   * }
+   **/
+  export interface QueryTypes {
+  }
+
 // overloaded useQuery function
 export function useQuery<TResult, TKey extends AnyQueryKey, TError = Error>({
   queryKey,
@@ -19,8 +32,8 @@ export function useQuery<TResult, TKey extends AnyQueryKey, TError = Error>({
 }): QueryResult<TResult, TError>
 
 export function useQuery<
-  TResult,
-  TSingleKey extends string,
+  TResult extends QueryTypes[TSingleKey],
+  TSingleKey extends keyof QueryTypes,
   TVariables extends AnyVariables = [],
   TError = Error
 >({
@@ -51,7 +64,7 @@ export function useQuery<TResult, TKey extends AnyQueryKey, TError = Error>(
   config?: QueryOptions<TResult, TError>
 ): QueryResult<TResult, TError>
 
-export function useQuery<TResult, TSingleKey extends string, TError = Error>(
+export function useQuery<TResult extends QueryTypes[TSingleKey], TSingleKey extends keyof QueryTypes, TError = Error>(
   queryKey:
     | TSingleKey
     | false
@@ -80,8 +93,8 @@ export function useQuery<
 ): QueryResult<TResult, TError>
 
 export function useQuery<
-  TResult,
-  TKey extends string,
+  TResult extends QueryTypes[TKey],
+  TKey extends keyof QueryTypes,
   TVariables extends AnyVariables,
   TError = Error
 >(

--- a/types/test.ts
+++ b/types/test.ts
@@ -20,6 +20,28 @@ function simpleQuery() {
   querySimple.isFetchingMore // $ExpectError
 }
 
+interface TodoItem {
+  text: string
+}
+
+
+declare module 'react-query' {
+  export interface QueryTypes {
+    'typed-todo': TodoItem
+  }
+}
+function globallyTyped() {
+  // Query - simple case
+  const querySimple = useQuery('typed-todo', () => Promise.resolve('test'))
+  querySimple.data // $ExpectType string | undefined
+  querySimple.error // $ExpectType Error | null
+  querySimple.isFetching // $ExpectType boolean
+  querySimple.refetch() // $ExpectType Promise<string>
+  querySimple.fetchMore // $ExpectError
+  querySimple.canFetchMore // $ExpectError
+  querySimple.isFetchingMore // $ExpectError
+}
+
 function queryWithVariables() {
   // Query Variables
   const param = 'test'


### PR DESCRIPTION
This is just an idea so haven't taken it very far. 

## The goal

To allow you to define the available keys and data types once and be enforced throughout the API

## Example

By putting this type in your code:

```
declare module 'react-query' {
  export interface QueryTypes {
    'typed-todo': TodoItem
  }
}
```

useQuery is now typed and the return type is enforced.

<img width="804" alt="image" src="https://user-images.githubusercontent.com/453152/85201531-ca2e7380-b332-11ea-838c-bdc1ea8fc745.png">

<img width="248" alt="image" src="https://user-images.githubusercontent.com/453152/85201688-fbf40a00-b333-11ea-8d31-d38db664d02c.png">

## Current issues

I have not yet figured out how to keep compatibility, the current approach will require the user to either define their types, or opt into the existing behavior by adding the following to their code.

```
declare module 'react-query' {
  export interface QueryTypes extends Record<string, any>
}
```

And also going through the entire public API to use the QueryTypes, we could use it to type the cache functions too