### PR TITLE
docs(guides/mutations): add 'throwOnError' option

### DIFF
--- a/docs/src/pages/docs/guides/mutations.mdx
+++ b/docs/src/pages/docs/guides/mutations.mdx
@@ -57,7 +57,8 @@ const CreateTodo = () => {
     e.preventDefault()
 
     try {
-      await mutate({ title })
+      // Set 'throwOnError: true' to re-throw failed mutations.
+      await mutate({ title }, { throwOnError: true })
       // Todo was successfully created
     } catch (error) {
       // Uh oh, something went wrong


### PR DESCRIPTION
I was working off the examples for useMutation trying to get a form submission to throw with errors from the back-end.
The rejected Promise from mutate wasn't getting caught in the try/catch. I now see in the API an option for throwOnError which is defaulted to false, so I added it to the useMutation example with the try/catch block.