### PR TITLE
Fix incorrect statement about Apollo

### DIFF
--- a/docs/src/pages/docs/comparison.md
+++ b/docs/src/pages/docs/comparison.md
@@ -17,7 +17,7 @@ Feature/Capability Key:
 | Supported Protocol                           | HTTP                                   | HTTP                                           | GraphQL                                                                   |
 | Supported Query Signatures                   | Promise                                | Promise                                        | GraphQL Query                                                             |
 | Supported Query Keys                         | JSON                                   | JSON                                           | GraphQL Query                                                             |
-| Query Key Change Detection                   | Deep Compare (Serialization)           | Referential Equality (===)                     | Referential Equality (===)                                                |
+| Query Key Change Detection                   | Deep Compare (Serialization)           | Referential Equality (===)                     | Deep Compare (Serialization)                                                |
 | Bundle Size                                  | [![][bp-react-query]][bpl-react-query] | [![][bp-swr]][bpl-swr]                         | [![][bp-apollo]][bpl-apollo]                                              |
 | Queries                                      | ✅                                     | ✅                                             | ✅                                                                        |
 | Caching                                      | ✅                                     | ✅                                             | ✅                                                                        |


### PR DESCRIPTION
Apollo does a deep comparison of the variables object when deciding whether or not the query needs to be re-executed. 

I can’t find this explicitly stated in the documentation unfortunately, but I know it to be true from experience. A quick squiz at the source code seems to indicate this is where it’s implemented:

https://github.com/trojanowski/react-apollo-hooks/blob/master/src/useQuery.ts#L119

(‘objToKey’ serialises the variables object.)