### PR TITLE
fix: docsearch is rendered twice with keyboard shortcuts

### DIFF
--- a/docs/src/components/LayoutDocs.js
+++ b/docs/src/components/LayoutDocs.js
@@ -60,7 +60,14 @@ export const LayoutDocs = props => {
       )}
       <div>
         {isMobile ? (
+          <>
           <Nav />
+          <Sticky shadow>
+              <SidebarMobile>
+                <SidebarRoutes isMobile={true} routes={routes} />
+              </SidebarMobile>
+          </Sticky>
+          </>
         ) : (
           <Sticky>
             <Nav />
@@ -72,11 +79,6 @@ export const LayoutDocs = props => {
         />
         <div className="block">
           <>
-            <Sticky shadow>
-              <SidebarMobile>
-                <SidebarRoutes isMobile={true} routes={routes} />
-              </SidebarMobile>
-            </Sticky>
 
             <div className="container mx-auto pb-12 pt-6 content">
               <div className="flex relative">

--- a/docs/src/components/LayoutDocs.js
+++ b/docs/src/components/LayoutDocs.js
@@ -61,12 +61,12 @@ export const LayoutDocs = props => {
       <div>
         {isMobile ? (
           <>
-          <Nav />
-          <Sticky shadow>
+            <Nav />
+            <Sticky shadow>
               <SidebarMobile>
                 <SidebarRoutes isMobile={true} routes={routes} />
               </SidebarMobile>
-          </Sticky>
+            </Sticky>
           </>
         ) : (
           <Sticky>
@@ -82,9 +82,11 @@ export const LayoutDocs = props => {
 
             <div className="container mx-auto pb-12 pt-6 content">
               <div className="flex relative">
-                <Sidebar fixed>
-                  <SidebarRoutes routes={routes} />
-                </Sidebar>
+                {!isMobile && (
+                  <Sidebar fixed>
+                    <SidebarRoutes routes={routes} />
+                  </Sidebar>
+                )}
 
                 <div className={s['markdown'] + ' w-full docs'}>
                   <h1>{props.meta.title}</h1>


### PR DESCRIPTION
the search modal appears twice when a user opens it with cmd + k. 

![Screenshot 2020-07-10 at 9 46 43 PM](https://user-images.githubusercontent.com/28605803/87161266-dc2e8100-c2f6-11ea-926e-bf6908571b1d.png)