### PR TITLE
Add Best of JS badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hooks for fetching, caching and updating asynchronous data in React
     <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
   </a><a href="https://github.com/tannerlinsley/react-query/discussions">
   <img alt="Join the discussion on Github" src="https://img.shields.io/badge/Github%20Discussions%20%26%20Support-Chat%20now!-blue" />
-</a><a href="https://github.com/tannerlinsley/react-query" target="\_parent">
+</a><a href="https://bestofjs.org/projects/react-query"><img alt="Best of JS" src="https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=tannerlinsley%2Freact-query%26since=daily" /></a><a href="https://github.com/tannerlinsley/react-query" target="\_parent">
   <img alt="" src="https://img.shields.io/github/stars/tannerlinsley/react-query.svg?style=social&label=Star" />
 </a><a href="https://twitter.com/tannerlinsley" target="\_parent">
   <img alt="" src="https://img.shields.io/twitter/follow/tannerlinsley.svg?style=social&label=Follow" />


### PR DESCRIPTION
Hello again Tanner @tannerlinsley !
Following the discussion here https://github.com/michaelrambeau/bestofjs/issues/323#issuecomment-650675957 this PR adds a badge that shows the number of stars added on GitHub since the previous day.

It should render this:

[![Best of JS](https://img.shields.io/endpoint?url=https://bestofjs-serverless.now.sh/api/project-badge?fullName=tannerlinsley%2Freact-query%26since=daily)](https://bestofjs.org/projects/react-query)

It's only a suggestion, feel free to reject this PR if you feel that you have already too many badges or if you think this data is not useful.

Thank you!