### PR TITLE
fix: use generic Error type in ReactQueryProviderConfig.queries

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -668,7 +668,7 @@ export function ReactQueryConfigProvider<TError = Error>(props: {
 }): React.ReactElement
 
 export interface ReactQueryProviderConfig<TError = Error> {
-  queries?: BaseQueryOptions & {
+  queries?: BaseQueryOptions<unknown, TError> & {
     /** Defaults to the value of `suspense` if not defined otherwise */
     useErrorBoundary?: boolean
     refetchOnWindowFocus?: boolean


### PR DESCRIPTION
Fixes #718