### PR TITLE
Fix makeQueryCache default caching behaviour in node

### DIFF
--- a/src/core/queryCache.js
+++ b/src/core/queryCache.js
@@ -8,16 +8,16 @@ import {
 import { defaultConfigRef } from './config'
 import { makeQuery } from './query'
 
-export const queryCache = makeQueryCache()
+export const queryCache = makeQueryCache({ frozen: isServer })
 
 export const queryCaches = [queryCache]
 
-export function makeQueryCache({ frozen = isServer, defaultConfig } = {}) {
+export function makeQueryCache({ frozen = false, defaultConfig } = {}) {
   // A frozen cache does not add new queries to the cache
   const globalListeners = []
 
   const configRef = defaultConfig
-    ? { current: { ...defaultConfigRef.current, ...defaultConfig }}
+    ? { current: { ...defaultConfigRef.current, ...defaultConfig } }
     : defaultConfigRef
 
   const queryCache = {


### PR DESCRIPTION
Closes #706

This PR makes it so caches returned from `makeQueryCache` will always be unfrozen, and therefor cache data, by default. This now includes on the server.

The global cache on the server is still frozen by default and does not cache data, this is to avoid leaking data across requests as per #70.

This makes it so the behaviour of `makeQueryCache` matches the one described in the Readme.

I also made the tests around this more explicit.