### PR TITLE
docs: add missing options in useQuery's api reference

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -28,12 +28,15 @@ const {
   cacheTime,
   refetchOnWindowFocus,
   refetchInterval,
+  refetchIntervalInBackground,
   queryFnParamsFilter,
   refetchOnMount,
   isDataEqual,
   onError,
   onSuccess,
   onSettled,
+  initialData,
+  initialStale,
   useErrorBoundary,
 })
 


### PR DESCRIPTION
useQuery's API reference code is missing these while they are in the options below it - refetchIntervalInBackground, initialData, initialStale,

This PR adds them.