### PR TITLE
fix: reduce the number of renders

### DIFF
--- a/src/core/tests/utils.test.js
+++ b/src/core/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { setConsole, queryCache, queryCaches } from '../'
-import { deepEqual } from '../utils'
+import { deepEqual, shallowEqual } from '../utils'
 
 describe('core/utils', () => {
   afterEach(() => {
@@ -28,17 +28,76 @@ describe('core/utils', () => {
     setConsole(console)
   })
 
-  it('deepequal should return `false` for different dates', () => {
-    const date1 = new Date(2020, 3, 1)
-    const date2 = new Date(2020, 3, 2)
+  describe('deepEqual', () => {
+    it('should return `true` for equal objects', () => {
+      const a = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
+      const b = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
+      expect(deepEqual(a, b)).toEqual(true)
+    })
 
-    expect(deepEqual(date1, date2)).toEqual(false)
+    it('should return `false` for non equal objects', () => {
+      const a = { a: { b: 'b' }, c: 'c' }
+      const b = { a: { b: 'c' }, c: 'c' }
+      expect(deepEqual(a, b)).toEqual(false)
+    })
+
+    it('should return `false` for different dates', () => {
+      const date1 = new Date(2020, 3, 1)
+      const date2 = new Date(2020, 3, 2)
+      expect(deepEqual(date1, date2)).toEqual(false)
+    })
+
+    it('return `true` for equal dates', () => {
+      const date1 = new Date(2020, 3, 1)
+      const date2 = new Date(2020, 3, 1)
+      expect(deepEqual(date1, date2)).toEqual(true)
+    })
   })
 
-  it('should return `true` for equal dates', () => {
-    const date1 = new Date(2020, 3, 1)
-    const date2 = new Date(2020, 3, 1)
+  describe('shallowEqual', () => {
+    it('should return `true` for empty objects', () => {
+      expect(shallowEqual({}, {})).toEqual(true)
+    })
 
-    expect(deepEqual(date1, date2)).toEqual(true)
+    it('should return `true` for equal values', () => {
+      expect(shallowEqual(1, 1)).toEqual(true)
+    })
+
+    it('should return `true` for equal arrays', () => {
+      expect(shallowEqual([1, 2], [1, 2])).toEqual(true)
+    })
+
+    it('should return `true` for equal shallow objects', () => {
+      const a = { a: 'a', b: 'b' }
+      const b = { a: 'a', b: 'b' }
+      expect(shallowEqual(a, b)).toEqual(true)
+    })
+
+    it('should return `true` for equal deep objects with same identities', () => {
+      const deep = { b: 'b' }
+      const a = { a: deep, c: 'c' }
+      const b = { a: deep, c: 'c' }
+      expect(shallowEqual(a, b)).toEqual(true)
+    })
+
+    it('should return `false` for non equal values', () => {
+      expect(shallowEqual(1, 2)).toEqual(false)
+    })
+
+    it('should return `false` for equal arrays', () => {
+      expect(shallowEqual([1, 2], [1, 3])).toEqual(false)
+    })
+
+    it('should return `false` for non equal shallow objects', () => {
+      const a = { a: 'a', b: 'b' }
+      const b = { a: 'a', b: 'c' }
+      expect(shallowEqual(a, b)).toEqual(false)
+    })
+
+    it('should return `false` for equal deep objects with different identities', () => {
+      const a = { a: { b: 'b' }, c: 'c' }
+      const b = { a: { b: 'b' }, c: 'c' }
+      expect(shallowEqual(a, b)).toEqual(false)
+    })
   })
 })

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -90,18 +90,33 @@ export function getQueryArgs(args) {
   return [queryKey, queryFn ? { ...config, queryFn } : config, ...rest]
 }
 
+export function deepEqual(a, b) {
+  return equal(a, b, true)
+}
+
+export function shallowEqual(a, b) {
+  return equal(a, b, false)
+}
+
 // This deep-equal is directly based on https://github.com/epoberezkin/fast-deep-equal.
 // The parts for comparing any non-JSON-supported values has been removed
-export function deepEqual(a, b) {
+function equal(a, b, deep, depth = 0) {
   if (a === b) return true
 
-  if (a && b && typeof a == 'object' && typeof b == 'object') {
+  if (
+    (deep || !depth) &&
+    a &&
+    b &&
+    typeof a == 'object' &&
+    typeof b == 'object'
+  ) {
     var length, i, keys
     if (Array.isArray(a)) {
       length = a.length
       // eslint-disable-next-line eqeqeq
       if (length != b.length) return false
-      for (i = length; i-- !== 0; ) if (!deepEqual(a[i], b[i])) return false
+      for (i = length; i-- !== 0; )
+        if (!equal(a[i], b[i], deep, depth + 1)) return false
       return true
     }
 
@@ -118,7 +133,7 @@ export function deepEqual(a, b) {
     for (i = length; i-- !== 0; ) {
       var key = keys[i]
 
-      if (!deepEqual(a[key], b[key])) return false
+      if (!equal(a[key], b[key], deep, depth + 1)) return false
     }
 
     return true

--- a/src/react/tests/useInfiniteQuery.test.js
+++ b/src/react/tests/useInfiniteQuery.test.js
@@ -28,6 +28,72 @@ describe('useInfiniteQuery', () => {
     queryCaches.forEach(cache => cache.clear({ notify: false }))
   })
 
+  it('should return the correct states for a successful query', async () => {
+    let count = 0
+    const states = []
+
+    function Page() {
+      const state = useInfiniteQuery(
+        'items',
+        (key, nextId = 0) => fetchItems(nextId, count++),
+        {
+          getFetchMore: (lastGroup, allGroups) => Boolean(lastGroup.nextId),
+        }
+      )
+
+      states.push(state)
+
+      return (
+        <div>
+          <h1>Status: {state.status}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitFor(() => rendered.getByText('Status: success'))
+
+    expect(states[0]).toMatchObject({
+      clear: expect.any(Function),
+      data: undefined,
+      error: null,
+      failureCount: 0,
+      fetchMore: expect.any(Function),
+      isError: false,
+      isFetching: true,
+      isIdle: false,
+      isLoading: true,
+      isStale: true,
+      isSuccess: false,
+      refetch: expect.any(Function),
+      status: 'loading',
+    })
+
+    expect(states[1]).toMatchObject({
+      clear: expect.any(Function),
+      canFetchMore: true,
+      data: [
+        {
+          items: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+          nextId: 1,
+          ts: 0,
+        },
+      ],
+      error: null,
+      failureCount: 0,
+      fetchMore: expect.any(Function),
+      isError: false,
+      isFetching: false,
+      isIdle: false,
+      isLoading: false,
+      isStale: true,
+      isSuccess: true,
+      refetch: expect.any(Function),
+      status: 'success',
+    })
+  })
+
   it('should allow you to fetch more pages', async () => {
     function Page() {
       const fetchCountRef = React.useRef(0)

--- a/src/react/tests/usePaginatedQuery.test.js
+++ b/src/react/tests/usePaginatedQuery.test.js
@@ -9,6 +9,63 @@ describe('usePaginatedQuery', () => {
     queryCaches.forEach(cache => cache.clear({ notify: false }))
   })
 
+  it('should return the correct states for a successful query', async () => {
+    const states = []
+
+    function Page() {
+      const state = usePaginatedQuery(['data', 1], async (queryName, page) => {
+        await sleep(10)
+        return page
+      })
+
+      states.push(state)
+
+      return (
+        <div>
+          <h1>Status: {state.status}</h1>
+        </div>
+      )
+    }
+
+    const rendered = render(<Page />)
+
+    await waitFor(() => rendered.getByText('Status: success'))
+
+    expect(states[0]).toMatchObject({
+      clear: expect.any(Function),
+      data: undefined,
+      error: null,
+      failureCount: 0,
+      isError: false,
+      isFetching: true,
+      isIdle: false,
+      isLoading: true,
+      isStale: true,
+      isSuccess: false,
+      latestData: undefined,
+      resolvedData: undefined,
+      refetch: expect.any(Function),
+      status: 'loading',
+    })
+
+    expect(states[1]).toMatchObject({
+      clear: expect.any(Function),
+      data: 1,
+      error: null,
+      failureCount: 0,
+      isError: false,
+      isFetching: false,
+      isIdle: false,
+      isLoading: false,
+      isStale: true,
+      isSuccess: true,
+      latestData: 1,
+      resolvedData: 1,
+      refetch: expect.any(Function),
+      status: 'success',
+    })
+  })
+
   it('should use previous page data while fetching the next page', async () => {
     function Page() {
       const [page, setPage] = React.useState(1)

--- a/src/react/useBaseQuery.js
+++ b/src/react/useBaseQuery.js
@@ -3,11 +3,11 @@ import React from 'react'
 //
 
 import { useQueryCache } from './ReactQueryCacheProvider'
-import { useMountedCallback } from './utils'
+import { useRerenderer } from './utils'
 
 export function useBaseQuery(queryKey, config = {}) {
   // Make a rerender function
-  const rerender = useMountedCallback(React.useState()[1])
+  const rerender = useRerenderer()
 
   // Get the query cache
   const queryCache = useQueryCache()
@@ -20,7 +20,9 @@ export function useBaseQuery(queryKey, config = {}) {
 
   // Subscribe to the query when the subscribe function changes
   React.useEffect(() => {
-    instanceRef.current = query.subscribe(() => rerender({}))
+    instanceRef.current = query.subscribe(() => {
+      rerender()
+    })
 
     // Unsubscribe when things change
     return instanceRef.current.unsubscribe
@@ -41,15 +43,9 @@ export function useBaseQuery(queryKey, config = {}) {
     instanceRef.current.run()
   }, [enabledBool, query])
 
-  const queryState = query.state
-
-  const queryInfoRef = React.useRef({})
-
-  Object.assign(queryInfoRef.current, {
+  return {
     ...query,
-    ...queryState,
+    ...query.state,
     query,
-  })
-
-  return queryInfoRef.current
+  }
 }

--- a/src/react/useIsFetching.js
+++ b/src/react/useIsFetching.js
@@ -1,24 +1,21 @@
 import React from 'react'
 
-import { useMountedCallback, useGetLatest } from './utils'
+import { useRerenderer, useGetLatest } from './utils'
 import { useQueryCache } from './ReactQueryCacheProvider'
 
 export function useIsFetching() {
   const queryCache = useQueryCache()
-  const [state, unsafeRerender] = React.useReducer(d => d + 1, 1)
-  const rerender = useMountedCallback(unsafeRerender)
-
-  const isFetching = React.useMemo(() => state && queryCache.isFetching, [
-    queryCache.isFetching,
-    state,
-  ])
+  const rerender = useRerenderer()
+  const isFetching = queryCache.isFetching
 
   const getIsFetching = useGetLatest(isFetching)
 
   React.useEffect(
     () =>
       queryCache.subscribe(newCache => {
-        if (getIsFetching() !== newCache.isFetching) rerender()
+        if (getIsFetching() !== newCache.isFetching) {
+          rerender()
+        }
       }),
     [getIsFetching, queryCache, rerender]
   )

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -56,25 +56,23 @@ export function useMountedCallback(callback) {
   )
 }
 
+export function useRerenderer() {
+  const rerender = useMountedCallback(React.useState()[1])
+  return React.useCallback(() => rerender({}), [rerender])
+}
+
 export function handleSuspense(queryInfo) {
-  if (
-    queryInfo.query.config.suspense ||
-    queryInfo.query.config.useErrorBoundary
-  ) {
-    if (
-      queryInfo.query.state.status === statusError &&
-      queryInfo.query.state.throwInErrorBoundary
-    ) {
-      throw queryInfo.error
+  const { error, query } = queryInfo
+  const { config, state } = query
+
+  if (config.suspense || config.useErrorBoundary) {
+    if (state.status === statusError && state.throwInErrorBoundary) {
+      throw error
     }
 
-    if (
-      queryInfo.query.config.suspense &&
-      queryInfo.status !== statusSuccess &&
-      queryInfo.query.config.enabled
-    ) {
-      queryInfo.query.wasSuspended = true
-      throw queryInfo.query.fetch()
+    if (config.suspense && state.status !== statusSuccess && config.enabled) {
+      query.wasSuspended = true
+      throw query.fetch()
     }
   }
 }


### PR DESCRIPTION
Hi there! This PR includes the following changes:

- Make sure the hook return values match the public APIs.
- Make sure the hooks only re-render when something has changed.
- Make sure the hook return values are stable / memoized.
- Batch the isStale and succes update together when possible.
- Batch the failureCount and error update together when possible.

With these changes, the number of renders for successful and unsuccessful queries can be reduced from 4 to 2.

PS: While working on the tests, I noticed the `canFetchMore` and `isFetchingMore` properties are sometimes set to `undefined`. I guess this is not correct? For now I matched the assertions with the current behaviour.