### PR TITLE
fix(types): pass CachedQuery TError down to CachedQueryState

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -515,9 +515,9 @@ export type MutationResult<TResult, TError = Error> =
   | ErrorMutationResult<TResult, TError>
   | SuccessMutationResult<TResult>
 
-export interface CachedQueryState<T> {
+export interface CachedQueryState<T, TError = Error> {
   data?: T
-  error?: Error | null
+  error?: TError | null
   failureCount: number
   isFetching: boolean
   canFetchMore?: boolean
@@ -530,7 +530,7 @@ export interface CachedQuery<T, TError = unknown> {
   queryKey: AnyQueryKey
   queryFn: (...args: any[]) => unknown
   config: QueryOptions<unknown, TError>
-  state: CachedQueryState<T>
+  state: CachedQueryState<T, TError>
   setData(
     dataOrUpdater:
       | unknown

--- a/types/test.ts
+++ b/types/test.ts
@@ -7,6 +7,7 @@ import {
   usePaginatedQuery,
   useQuery,
   queryCache,
+  CachedQuery,
 } from 'react-query'
 
 class FooError extends Error {}
@@ -63,6 +64,11 @@ function getQueries() {
   queryCache.getQueries('queryKey');
   queryCache.getQueries(true);
   queryCache.getQueries((query) => true);
+}
+
+function cachedQueryErrorState() {
+  const query = queryCache.getQuery(['queryKey']) as CachedQuery<unknown, FooError>
+  const error: FooError | null | undefined = query.state.error;
 }
 
 function simpleQuery() {


### PR DESCRIPTION
## Changes

- Allow passing `CachedQuery<T, TError>` down to `CachedQueryState<T, TError>` for casting purposes

## Usage

When you **know** the query typings you expect (such as when wrapping with your own abstraction like we do), you should be able to safely cast the type of `CachedQuery`.

```js
interface MyCustomResult<TResult, TError> {
  data: TResult | undefined
  error: TError | null
}

// Somewhere else...

function wrap(): MyCustomResult<TResult, TError> {
  const queryData = queryCache.getQueryData<TResult>(queryKey);
  const query = queryCache.getQuery(queryKey) as CachedQuery<TResult, TError> | undefined ;

  return {
    data: queryData,
    error: query?.state.error ?? null
  }
}
```