### PR TITLE
fix(ReactQueryCacheProvider): use shared `queryCaches`

### DIFF
--- a/src/react/ReactQueryCacheProvider.js
+++ b/src/react/ReactQueryCacheProvider.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import { queryCache, makeQueryCache } from '../core'
+import { queryCache as defaultQueryCache, queryCaches, makeQueryCache } from '../core'
 
-export const queryCacheContext = React.createContext(queryCache)
-
-export const queryCaches = [queryCache]
+export const queryCacheContext = React.createContext(defaultQueryCache)
 
 export const useQueryCache = () => React.useContext(queryCacheContext)
 


### PR DESCRIPTION
`ReactQueryCacheProvider` uses own `queryCaches`, looks like a typo after refactoring.

Due to that typo, `onWindowFocus` is completely broken when isolated query cache is used.