### PR TITLE
v3: Remove refetchOnMount and always fetch when stale

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -32,7 +32,7 @@ const {
   refetchIntervalInBackground,
   queryFnParamsFilter,
   refetchOnMount,
-  alwaysRefetchOnMount,
+  neverRefetchOnMount,
   isDataEqual,
   onError,
   onSuccess,
@@ -117,10 +117,10 @@ const queryInfo = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, will disable additional instances of a query to trigger background refetches
-- `alwaysRefetchOnMount: Boolean`
+- `neverRefetchOnMount: Boolean`
   - Optional
   - Defaults to `false`
-  - Always refetch on mount sets refetching independent of the number of query instances. If `refetchOnMount` is set to false but only one query instance exists the query would refetch anyway. If `alwaysRefetchOnMount` is set to false though the query will not refetch independent of the number of instances
+  - Allows for disabling refetching on mount independent of the number of query instances. If `refetchOnMount` is set to false but only one query instance exists the query would refetch anyway. If `neverRefetchOnMount` is set to true though the query will not refetch independent of the number of query instances.
 - `queryFnParamsFilter: Function(args) => filteredArgs`
   - Optional
   - This function will filter the params that get passed to `queryFn`.
@@ -670,7 +670,7 @@ const queryConfig = {
     refetchInterval: false,
     queryFnParamsFilter: identity,
     refetchOnMount: true,
-    alwaysRefetchOnMount: false,
+    neverRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -31,8 +31,6 @@ const {
   refetchInterval,
   refetchIntervalInBackground,
   queryFnParamsFilter,
-  refetchOnMount,
-  neverRefetchOnMount,
   isDataEqual,
   onError,
   onSuccess,
@@ -113,14 +111,6 @@ const queryInfo = useQuery({
   - Optional
   - If set, this will mark any `initialData` provided as stale and will likely cause it to be refetched on mount
   - If a function is passed, it will be called only when appropriate to resolve the `initialStale` value. This can be useful if your `initialStale` value is costly to calculate.
-- `refetchOnMount: Boolean`
-  - Optional
-  - Defaults to `true`
-  - If set to `false`, will disable additional instances of a query to trigger background refetches
-- `neverRefetchOnMount: Boolean`
-  - Optional
-  - Defaults to `false`
-  - Allows for disabling refetching on mount independent of the number of query instances. If `refetchOnMount` is set to false but only one query instance exists the query would refetch anyway. If `neverRefetchOnMount` is set to true though the query will not refetch independent of the number of query instances.
 - `queryFnParamsFilter: Function(args) => filteredArgs`
   - Optional
   - This function will filter the params that get passed to `queryFn`.
@@ -669,8 +659,6 @@ const queryConfig = {
     refetchOnWindowFocus: true,
     refetchInterval: false,
     queryFnParamsFilter: identity,
-    refetchOnMount: true,
-    neverRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -32,6 +32,7 @@ const {
   refetchIntervalInBackground,
   queryFnParamsFilter,
   refetchOnMount,
+  alwaysRefetchOnMount,
   isDataEqual,
   onError,
   onSuccess,
@@ -116,6 +117,10 @@ const queryInfo = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, will disable additional instances of a query to trigger background refetches
+- `alwaysRefetchOnMount: Boolean`
+  - Optional
+  - Defaults to `false`
+  - Always refetch on mount sets refetching independent of the number of query instances. If `refetchOnMount` is set to false but only one query instance exists the query would refetch anyway. If `alwaysRefetchOnMount` is set to false though the query will not refetch independent of the number of instances
 - `queryFnParamsFilter: Function(args) => filteredArgs`
   - Optional
   - This function will filter the params that get passed to `queryFn`.
@@ -665,6 +670,7 @@ const queryConfig = {
     refetchInterval: false,
     queryFnParamsFilter: identity,
     refetchOnMount: true,
+    alwaysRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
     refetchInterval: false,
     queryFnParamsFilter: identity,
     refetchOnMount: true,
-    alwaysRefetchOnMount: false,
+    neverRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -17,6 +17,7 @@ export const DEFAULT_CONFIG = {
     refetchInterval: false,
     queryFnParamsFilter: identity,
     refetchOnMount: true,
+    alwaysRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -16,8 +16,6 @@ export const DEFAULT_CONFIG = {
     refetchOnWindowFocus: true,
     refetchInterval: false,
     queryFnParamsFilter: identity,
-    refetchOnMount: true,
-    neverRefetchOnMount: false,
     isDataEqual: deepEqual,
     onError: noop,
     onSuccess: noop,

--- a/src/core/queryInstance.js
+++ b/src/core/queryInstance.js
@@ -50,16 +50,10 @@ export function makeQueryInstance(query, onStateUpdate) {
 
   instance.run = async () => {
     try {
-
-      // Don't refetch on mount when 'neverRefetchOnMount' is set, otherwise only refetch if either only one instance of the query exists or 'refetchOnMount' is set
-      const shouldRefetchOnMount = query.config.neverRefetchOnMount ? false : (query.config.refetchOnMount || query.instances.length === 1);
-
       if(
-        (!query.state.isSuccess || shouldRefetchOnMount) && // Make sure first load happens, thereafter only if refetch on mount is requested
         query.config.enabled && // Don't auto refetch if disabled
         !query.wasSuspended && // Don't double refetch for suspense
         query.state.isStale // Only refetch if stale
-        
       ) {
         await query.fetch();
       }

--- a/src/core/queryInstance.js
+++ b/src/core/queryInstance.js
@@ -55,7 +55,7 @@ export function makeQueryInstance(query, onStateUpdate) {
         query.config.enabled && // Don't auto refetch if disabled
         !query.wasSuspended && // Don't double refetch for suspense
         query.state.isStale && // Only refetch if stale
-        (query.config.refetchOnMount || query.instances.length === 1)
+        ((query.config.refetchOnMount || query.instances.length === 1) || query.config.alwaysRefetchOnMount)
       ) {
         await query.fetch()
       }

--- a/src/core/queryInstance.js
+++ b/src/core/queryInstance.js
@@ -50,14 +50,18 @@ export function makeQueryInstance(query, onStateUpdate) {
 
   instance.run = async () => {
     try {
-      // Perform the refetch for this query if necessary
-      if (
+
+      // Don't refetch on mount when 'neverRefetchOnMount' is set, otherwise only refetch if either only one instance of the query exists or 'refetchOnMount' is set
+      const shouldRefetchOnMount = query.config.neverRefetchOnMount ? false : (query.config.refetchOnMount || query.instances.length === 1);
+
+      if(
+        (!query.state.isSuccess || shouldRefetchOnMount) && // Make sure first load happens, thereafter only if refetch on mount is requested
         query.config.enabled && // Don't auto refetch if disabled
         !query.wasSuspended && // Don't double refetch for suspense
-        query.state.isStale && // Only refetch if stale
-        ((query.config.refetchOnMount || query.instances.length === 1) || query.config.alwaysRefetchOnMount)
+        query.state.isStale // Only refetch if stale
+        
       ) {
-        await query.fetch()
+        await query.fetch();
       }
 
       query.wasSuspended = false

--- a/src/react/tests/ReactQueryConfigProvider.test.js
+++ b/src/react/tests/ReactQueryConfigProvider.test.js
@@ -97,7 +97,6 @@ describe('ReactQueryConfigProvider', () => {
     const config = {
       queries: {
         refetchOnWindowFocus: false,
-        refetchOnMount: false,
         retry: false,
       },
     }
@@ -143,7 +142,7 @@ describe('ReactQueryConfigProvider', () => {
     await waitFor(() => rendered.findByText('Data: data'))
 
     // tear down and unmount
-    // so we are NOT passing the config above (refetchOnMount should be `true` by default)
+    // so we are NOT passing the config above
     fireEvent.click(rendered.getByText('unmount'))
 
     act(() => {
@@ -161,15 +160,12 @@ describe('ReactQueryConfigProvider', () => {
 
     const parentConfig = {
       queries: {
-        refetchOnMount: false,
         onSuccess: parentOnSuccess,
       },
     }
 
     const childConfig = {
       queries: {
-        refetchOnMount: true,
-
         // Override onSuccess of parent, making it a no-op
         onSuccess: undefined,
       },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -237,6 +237,7 @@ export interface BaseQueryOptions<TResult = unknown, TError = Error> {
   refetchIntervalInBackground?: boolean
   refetchOnWindowFocus?: boolean
   refetchOnMount?: boolean
+  alwaysRefetchOnMount?: boolean
   onSuccess?: (data: TResult) => void
   onError?: (err: TError) => void
   onSettled?: (data: TResult | undefined, error: TError | null) => void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -236,8 +236,6 @@ export interface BaseQueryOptions<TResult = unknown, TError = Error> {
   refetchInterval?: false | number
   refetchIntervalInBackground?: boolean
   refetchOnWindowFocus?: boolean
-  refetchOnMount?: boolean
-  neverRefetchOnMount?: boolean
   onSuccess?: (data: TResult) => void
   onError?: (err: TError) => void
   onSettled?: (data: TResult | undefined, error: TError | null) => void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -237,7 +237,7 @@ export interface BaseQueryOptions<TResult = unknown, TError = Error> {
   refetchIntervalInBackground?: boolean
   refetchOnWindowFocus?: boolean
   refetchOnMount?: boolean
-  alwaysRefetchOnMount?: boolean
+  neverRefetchOnMount?: boolean
   onSuccess?: (data: TResult) => void
   onError?: (err: TError) => void
   onSettled?: (data: TResult | undefined, error: TError | null) => void


### PR DESCRIPTION
This PR removes the refetchOnMount option which was used as a condition for refetching/fetching the query. Instead of this the query refetching will depend purely on whether a query is stale, enabled and not suspended.