### PR TITLE
Adds TS version requirement

### DIFF
--- a/docs/src/pages/docs/typescript.md
+++ b/docs/src/pages/docs/typescript.md
@@ -22,4 +22,4 @@ npm install react-query@tsnext --save
 ## Changes
 
 - The query results are no longer discriminated unions, which means you have to check the actual `data` and `error` properties.
-- Require TypeScript v3.8 or greater
+- Requires TypeScript v3.8 or greater

--- a/docs/src/pages/docs/typescript.md
+++ b/docs/src/pages/docs/typescript.md
@@ -22,3 +22,4 @@ npm install react-query@tsnext --save
 ## Changes
 
 - The query results are no longer discriminated unions, which means you have to check the actual `data` and `error` properties.
+- Require TypeScript v3.8 or greater


### PR DESCRIPTION
The new type defs include the `export type` syntax that was added in TS 3.8

Add this to the docs to inform people of the version requirement