### PR TITLE
chore: mutationFn should return a Promise type

### DIFF
--- a/docs/src/pages/docs/guides/mutations.md
+++ b/docs/src/pages/docs/guides/mutations.md
@@ -87,7 +87,7 @@ Note that since version 1.1.0, the `mutate` function is no longer called synchro
 const CreateTodo = () => {
   const [mutate] = useMutation(event => {
     event.preventDefault()
-    fetch('/api', new FormData(event.target))
+    return fetch('/api', new FormData(event.target))
   })
 
   return <form onSubmit={mutate}>...</form>
@@ -96,7 +96,7 @@ const CreateTodo = () => {
 // This will work
 const CreateTodo = () => {
   const [mutate] = useMutation(formData => {
-    fetch('/api', formData)
+    return fetch('/api', formData)
   })
   const onSubmit = event => {
     event.preventDefault()


### PR DESCRIPTION
As seen at https://react-query.tanstack.com/docs/api#usemutation, 
> mutationFn: Function(variables) => Promise
Required
A function that performs an asynchronous task and returns a promise.
variables is an object that mutate will pass to your mutationFn

I correct the demo code