### PR TITLE
refactor: move prevent set state in render logic to useIsFetching hook

### DIFF
--- a/src/core/queryCache.ts
+++ b/src/core/queryCache.ts
@@ -5,6 +5,7 @@ import {
   Console,
   isObject,
   Updater,
+  functionalUpdate,
 } from './utils'
 import { defaultConfigRef, ReactQueryConfigRef } from './config'
 import { Query } from './query'
@@ -258,17 +259,7 @@ export class QueryCache {
 
       if (!this.config.frozen) {
         this.queries[queryHash] = query
-
-        if (isServer) {
-          this.notifyGlobalListeners()
-        } else {
-          // Here, we setTimeout so as to not trigger
-          // any setState's in parent components in the
-          // middle of the render phase.
-          setTimeout(() => {
-            this.notifyGlobalListeners()
-          })
-        }
+        this.notifyGlobalListeners(query)
       }
     }
 
@@ -378,13 +369,18 @@ export class QueryCache {
     updater: Updater<TResult | undefined, TResult>,
     config?: QueryConfig<TResult, TError>
   ) {
-    let query = this.getQuery<TResult, TError>(queryKey)
+    const query = this.getQuery<TResult, TError>(queryKey)
 
-    if (!query) {
-      query = this.buildQuery<TResult, TError>(queryKey, config)
+    if (query) {
+      query.setData(updater)
+      return
     }
 
-    query.setData(updater)
+    this.buildQuery<TResult, TError>(queryKey, {
+      initialStale: typeof config?.staleTime === 'undefined',
+      initialData: functionalUpdate(updater, undefined),
+      ...config,
+    })
   }
 }
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -20,7 +20,7 @@ export function useBaseQuery<TResult, TError>(
   React.useEffect(
     () =>
       observer.subscribe(() => {
-        Promise.resolve().then(rerender)
+        rerender()
       }),
     [observer, rerender]
   )

--- a/src/react/useIsFetching.ts
+++ b/src/react/useIsFetching.ts
@@ -1,23 +1,19 @@
 import React from 'react'
 
-import { useRerenderer, useGetLatest } from './utils'
 import { useQueryCache } from './ReactQueryCacheProvider'
+import { useSafeState } from './utils'
 
 export function useIsFetching(): number {
   const queryCache = useQueryCache()
-  const rerender = useRerenderer()
-  const isFetching = queryCache.isFetching
 
-  const getIsFetching = useGetLatest(isFetching)
+  const [isFetching, setIsFetching] = useSafeState(queryCache.isFetching)
 
   React.useEffect(
     () =>
-      queryCache.subscribe(newCache => {
-        if (getIsFetching() !== newCache.isFetching) {
-          rerender()
-        }
+      queryCache.subscribe(() => {
+        setIsFetching(queryCache.isFetching)
       }),
-    [getIsFetching, queryCache, rerender]
+    [queryCache, setIsFetching]
   )
 
   return isFetching

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,16 +1,6 @@
 import React from 'react'
 
-import { uid, isServer } from '../core/utils'
-
-export function useUid(): number {
-  const ref = React.useRef(0)
-
-  if (ref.current === null) {
-    ref.current = uid()
-  }
-
-  return ref.current
-}
+import { isServer } from '../core/utils'
 
 export function useGetLatest<T>(obj: T): () => T {
   const ref = React.useRef<T>(obj)
@@ -18,23 +8,72 @@ export function useGetLatest<T>(obj: T): () => T {
   return React.useCallback(() => ref.current, [])
 }
 
-export function useMountedCallback<T extends Function>(callback: T): T {
-  const mounted = React.useRef(false)
+function useIsMounted(): () => boolean {
+  const mountedRef = React.useRef(false)
+  const isMounted = React.useCallback(() => mountedRef.current, [])
 
   React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
-    mounted.current = true
+    mountedRef.current = true
     return () => {
-      mounted.current = false
+      mountedRef.current = false
     }
   }, [])
 
+  return isMounted
+}
+
+export function useMountedCallback<T extends Function>(callback: T): T {
+  const isMounted = useIsMounted()
   return (React.useCallback(
-    (...args: any[]) => (mounted.current ? callback(...args) : void 0),
-    [callback]
+    (...args: any[]) => {
+      if (isMounted()) {
+        return callback(...args)
+      }
+    },
+    [callback, isMounted]
   ) as any) as T
 }
 
+/**
+ * This hook is a safe useState version which schedules state updates in microtasks
+ * to prevent updating a component state while React is rendering different components
+ * or when the component is not mounted anymore.
+ */
+export function useSafeState<S>(
+  initialState: S | (() => S)
+): [S, React.Dispatch<React.SetStateAction<S>>] {
+  const isMounted = useIsMounted()
+  const [state, setState] = React.useState(initialState)
+
+  const safeSetState = React.useCallback(
+    (value: React.SetStateAction<S>) => {
+      scheduleMicrotask(() => {
+        if (isMounted()) {
+          setState(value)
+        }
+      })
+    },
+    [isMounted]
+  )
+
+  return [state, safeSetState]
+}
+
 export function useRerenderer() {
-  const rerender = useMountedCallback(React.useState<unknown>()[1])
-  return React.useCallback(() => rerender({}), [rerender])
+  const [, setState] = useSafeState({})
+  return React.useCallback(() => setState({}), [setState])
+}
+
+/**
+ * Schedules a microtask.
+ * This can be useful to schedule state updates after rendering.
+ */
+function scheduleMicrotask(callback: () => void): void {
+  Promise.resolve()
+    .then(callback)
+    .catch(error =>
+      setTimeout(() => {
+        throw error
+      })
+    )
 }


### PR DESCRIPTION
Move prevent set state in render logic to useIsFetching hook to make QueryCache less aware of React