### PR TITLE
feat: make sure paused queries resolve

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,13 @@
 export { queryCache, queryCaches, makeQueryCache } from './queryCache'
 export { setFocusHandler } from './setFocusHandler'
-export { stableStringify, setConsole, deepIncludes } from './utils'
+export {
+  CancelledError,
+  deepIncludes,
+  isCancelledError,
+  isError,
+  setConsole,
+  stableStringify,
+} from './utils'
 
 // Types
 export * from './types'

--- a/src/core/queryCache.ts
+++ b/src/core/queryCache.ts
@@ -1,11 +1,10 @@
 import {
-  isServer,
-  getQueryArgs,
-  deepIncludes,
-  Console,
-  isObject,
   Updater,
+  deepIncludes,
   functionalUpdate,
+  getQueryArgs,
+  isObject,
+  isServer,
 } from './utils'
 import { getDefaultedQueryConfig } from './config'
 import { Query } from './query'
@@ -310,11 +309,10 @@ export class QueryCache {
         await query.fetch()
       }
       return query.state.data
-    } catch (err) {
+    } catch (error) {
       if (options?.throwOnError) {
-        throw err
+        throw error
       }
-      Console.error(err)
       return
     }
   }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -1,4 +1,4 @@
-import { getStatusProps, isServer, isDocumentVisible, Console } from './utils'
+import { getStatusProps, isServer, isDocumentVisible } from './utils'
 import type { QueryResult, QueryObserverConfig } from './types'
 import type { Query, QueryState, Action, FetchMoreOptions, RefetchOptions } from './query'
 
@@ -101,10 +101,11 @@ export class QueryObserver<TResult, TError> {
 
   async fetch(): Promise<TResult | undefined> {
     this.currentQuery.updateConfig(this.config)
-    return this.currentQuery.fetch().catch(error => {
-      Console.error(error)
+    try {
+      return await this.currentQuery.fetch()
+    } catch (error) {
       return undefined
-    })
+    }
   }
 
   private optionalFetch(): void {

--- a/src/core/setFocusHandler.ts
+++ b/src/core/setFocusHandler.ts
@@ -8,22 +8,17 @@ const focusEvent = 'focus'
 
 const onWindowFocus: FocusHandler = () => {
   if (isDocumentVisible() && isOnline()) {
-    queryCaches.forEach(queryCache =>
+    queryCaches.forEach(queryCache => {
+      // Continue any paused queries
+      queryCache.getQueries(query => {
+        query.continue()
+      })
+
+      // Invalidate queries which should refetch on window focus
       queryCache
-        .invalidateQueries(query => {
-          if (!query.shouldRefetchOnWindowFocus()) {
-            return false
-          }
-
-          if (query.shouldContinueRetryOnFocus) {
-            // delete promise, so refetching will create new one
-            delete query.promise
-          }
-
-          return true
-        })
+        .invalidateQueries(query => query.shouldRefetchOnWindowFocus())
         .catch(Console.error)
-    )
+    })
   }
 }
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -16,16 +16,23 @@ export interface ConsoleObject {
   error: ConsoleFunction
 }
 
+interface Cancelable {
+  cancel(): void
+}
+
+export class CancelledError {}
+
 // UTILS
 
 let _uid = 0
 export const uid = () => _uid++
-export const cancelledError = {}
-export const globalStateListeners = []
+
 export const isServer = typeof window === 'undefined'
-export function noop(): void {
+
+function noop(): void {
   return void 0
 }
+
 export let Console: ConsoleObject = console || {
   error: noop,
   warn: noop,
@@ -199,6 +206,24 @@ function isPlainObject(o: any): o is Object {
 
 function hasObjectPrototype(o: any): boolean {
   return Object.prototype.toString.call(o) === '[object Object]'
+}
+
+export function isCancelable(value: any): value is Cancelable {
+  return typeof value?.cancel === 'function'
+}
+
+export function isError(value: any): value is Error {
+  return value instanceof Error
+}
+
+export function isCancelledError(value: any): value is CancelledError {
+  return value instanceof CancelledError
+}
+
+export function sleep(timeout: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout)
+  })
 }
 
 export function getStatusProps<T extends QueryStatus>(status: T) {

--- a/src/react/tests/ReactQueryCacheProvider.test.tsx
+++ b/src/react/tests/ReactQueryCacheProvider.test.tsx
@@ -141,7 +141,7 @@ describe('ReactQueryCacheProvider', () => {
     cache2.clear({ notify: false })
   })
 
-  test('when cache changes, previous cache is cleaned', () => {
+  test('when cache changes, previous cache is cleaned', async () => {
     const key = queryKey()
 
     const caches: QueryCache[] = []
@@ -149,6 +149,7 @@ describe('ReactQueryCacheProvider', () => {
 
     function Page() {
       const queryCache = useQueryCache()
+
       useEffect(() => {
         caches.push(queryCache)
       }, [queryCache])
@@ -175,6 +176,8 @@ describe('ReactQueryCacheProvider', () => {
 
     const rendered = render(<App />)
 
+    await waitFor(() => rendered.getByText('test'))
+
     expect(caches).toHaveLength(1)
     jest.spyOn(caches[0], 'clear')
 
@@ -182,6 +185,9 @@ describe('ReactQueryCacheProvider', () => {
 
     expect(caches).toHaveLength(2)
     expect(caches[0].clear).toHaveBeenCalled()
+
+    await waitFor(() => rendered.getByText('test'))
+
     customCache.clear({ notify: false })
   })
 

--- a/src/react/tests/suspense.test.tsx
+++ b/src/react/tests/suspense.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor, fireEvent } from '@testing-library/react'
 import { ErrorBoundary } from 'react-error-boundary'
 import * as React from 'react'
 
-import { sleep, queryKey } from './utils'
+import { sleep, queryKey, mockConsoleError } from './utils'
 import { useQuery } from '..'
 import { queryCache } from '../../core'
 
@@ -133,8 +133,7 @@ describe("useQuery's in Suspense mode", () => {
     const key = queryKey()
 
     let succeed = false
-    const consoleMock = jest.spyOn(console, 'error')
-    consoleMock.mockImplementation(() => undefined)
+    const consoleMock = mockConsoleError()
 
     function Page() {
       useQuery(

--- a/src/react/tests/useIsFetching.test.tsx
+++ b/src/react/tests/useIsFetching.test.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 
-import { sleep, queryKey } from './utils'
+import { sleep, queryKey, mockConsoleError } from './utils'
 import { useQuery, useIsFetching } from '..'
 
 describe('useIsFetching', () => {
@@ -42,7 +42,7 @@ describe('useIsFetching', () => {
   })
 
   it('should not update state while rendering', async () => {
-    const spy = jest.spyOn(console, 'error')
+    const consoleMock = mockConsoleError()
 
     const key1 = queryKey()
     const key2 = queryKey()
@@ -91,9 +91,9 @@ describe('useIsFetching', () => {
 
     render(<Page />)
     await waitFor(() => expect(isFetchings).toEqual([1, 1, 2, 1, 0]))
-    expect(spy).not.toHaveBeenCalled()
-    expect(spy.mock.calls[0]?.[0] ?? '').not.toMatch('setState')
+    expect(consoleMock).not.toHaveBeenCalled()
+    expect(consoleMock.mock.calls[0]?.[0] ?? '').not.toMatch('setState')
 
-    spy.mockRestore()
+    consoleMock.mockRestore()
   })
 })

--- a/src/react/tests/useMutation.test.tsx
+++ b/src/react/tests/useMutation.test.tsx
@@ -2,6 +2,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react'
 import * as React from 'react'
 
 import { useMutation } from '..'
+import { mockConsoleError } from './utils'
 
 describe('useMutation', () => {
   it('should be able to reset `data`', async () => {
@@ -37,8 +38,7 @@ describe('useMutation', () => {
   })
 
   it('should be able to reset `error`', async () => {
-    const consoleMock = jest.spyOn(console, 'error')
-    consoleMock.mockImplementation(() => undefined)
+    const consoleMock = mockConsoleError()
 
     function Page() {
       const [mutate, mutationResult] = useMutation<string, Error>(
@@ -128,8 +128,8 @@ describe('useMutation', () => {
   })
 
   it('should be able to call `onError` and `onSettled` after each failed mutate', async () => {
-    const consoleMock = jest.spyOn(console, 'error')
-    consoleMock.mockImplementation(() => undefined)
+    const consoleMock = mockConsoleError()
+
     const onErrorMock = jest.fn()
     const onSettledMock = jest.fn()
     let count = 0
@@ -189,5 +189,7 @@ describe('useMutation', () => {
     )
 
     expect(getByTestId('title').textContent).toBe('3')
+
+    consoleMock.mockRestore()
   })
 })

--- a/src/react/tests/utils.tsx
+++ b/src/react/tests/utils.tsx
@@ -1,5 +1,18 @@
 let queryKeyCount = 0
 
+export function mockVisibilityState(value: string) {
+  Object.defineProperty(document, 'visibilityState', {
+    value,
+    configurable: true,
+  })
+}
+
+export function mockConsoleError() {
+  const consoleMock = jest.spyOn(console, 'error')
+  consoleMock.mockImplementation(() => undefined)
+  return consoleMock
+}
+
 export function queryKey(): string {
   queryKeyCount++
   return `query_${queryKeyCount}`


### PR DESCRIPTION
This PR addresses three issues:
- Make sure existing promises also resolve when fetching is paused and resumed because of a window unfocus.
- Make sure existing promises also reject when fetching is cancelled. They will be rejected with a `CancelledError`.
- Make sure queries are still cached when the transport layer does not support cancellation.
- Set `CancelledError` as `error` to allow users to check if the query was cancelled (the `isCancelledError` helper function can be used to check if an error is a cancelled error).