### PR TITLE
refactor: reduce infinite query renders and bundle size

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,12 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off"
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-inferrable-types": [
+      "error",
+      {
+        "ignoreParameters": true
+      }
+    ]
   }
 }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -1,6 +1,12 @@
 import { getStatusProps, isServer, isDocumentVisible } from './utils'
 import type { QueryResult, QueryObserverConfig } from './types'
-import type { Query, QueryState, Action, FetchMoreOptions, RefetchOptions } from './query'
+import type {
+  Query,
+  QueryState,
+  Action,
+  FetchMoreOptions,
+  RefetchOptions,
+} from './query'
 
 export type UpdateListener<TResult, TError> = (
   result: QueryResult<TResult, TError>
@@ -37,11 +43,11 @@ export class QueryObserver<TResult, TError> {
     return this.unsubscribe.bind(this)
   }
 
-  unsubscribe(preventGC?: boolean): void {
+  unsubscribe(): void {
     this.started = false
     this.updateListener = undefined
     this.clearRefetchInterval()
-    this.currentQuery.unsubscribeObserver(this, preventGC)
+    this.currentQuery.unsubscribeObserver(this)
   }
 
   updateConfig(config: QueryObserverConfig<TResult, TError>): void {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,7 +33,7 @@ export type QueryKeySerializerFunction = (
   queryKey: QueryKey
 ) => [string, QueryKey[]]
 
-export interface BaseQueryConfig<TResult, TError = unknown> {
+export interface BaseQueryConfig<TResult, TError = unknown, TData = TResult> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -50,7 +50,7 @@ export interface BaseQueryConfig<TResult, TError = unknown> {
   staleTime?: number
   cacheTime?: number
   isDataEqual?: (oldData: unknown, newData: unknown) => boolean
-  queryFn?: QueryFunction<TResult>
+  queryFn?: QueryFunction<TData>
   queryKey?: QueryKey
   queryKeySerializerFn?: QueryKeySerializerFunction
   queryFnParamsFilter?: (args: ArrayQueryKey) => ArrayQueryKey
@@ -62,10 +62,18 @@ export interface BaseQueryConfig<TResult, TError = unknown> {
    * Defaults to `true`.
    */
   structuralSharing?: boolean
+  /**
+   * This function can be set to automatically get the next cursor for infinite queries.
+   * The result will also be used to determine the value of `canFetchMore`.
+   */
+  getFetchMore?: (lastPage: TData, allPages: TData[]) => unknown
 }
 
-export interface QueryObserverConfig<TResult, TError = unknown>
-  extends BaseQueryConfig<TResult, TError> {
+export interface QueryObserverConfig<
+  TResult,
+  TError = unknown,
+  TData = TResult
+> extends BaseQueryConfig<TResult, TError, TData> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -133,9 +141,7 @@ export interface PaginatedQueryConfig<TResult, TError = unknown>
   extends QueryObserverConfig<TResult, TError> {}
 
 export interface InfiniteQueryConfig<TResult, TError = unknown>
-  extends QueryObserverConfig<TResult[], TError> {
-  getFetchMore: (lastPage: TResult, allPages: TResult[]) => unknown
-}
+  extends QueryObserverConfig<TResult[], TError, TResult> {}
 
 export type IsFetchingMoreValue = 'previous' | 'next' | false
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -42,10 +42,8 @@ export function useBaseQuery<TResult, TError>(
     }
 
     if (config.enabled && config.suspense && !result.isSuccess) {
-      observer.subscribe()
-      throw observer.fetch().finally(() => {
-        observer.unsubscribe(true)
-      })
+      const unsubscribe = observer.subscribe()
+      throw observer.fetch().finally(unsubscribe)
     }
   }
 


### PR DESCRIPTION
This MR addresses the following things:
- Fixes bug where previously fetched pages were still remembered after setting new data with `setQueryData`.
- Prevent unnecessary renders while performing infinite queries.
- Reduce bundle size by around 10%.
- Also update `canFetchMore` when setting data with `setQueryData`.