### PR TITLE
Refactor query timeouts

### DIFF
--- a/src/core/queryCache.ts
+++ b/src/core/queryCache.ts
@@ -301,11 +301,9 @@ export class QueryCache {
     // https://github.com/tannerlinsley/react-query/issues/652
     const configWithoutRetry = { retry: false, ...config }
 
+    let query
     try {
-      const query = this.buildQuery<TResult, TError>(
-        queryKey,
-        configWithoutRetry
-      )
+      query = this.buildQuery<TResult, TError>(queryKey, configWithoutRetry)
       if (options?.force || query.state.isStale) {
         await query.fetch()
       }
@@ -316,6 +314,14 @@ export class QueryCache {
       }
       Console.error(err)
       return
+    } finally {
+      if (query) {
+        // When prefetching, no observer is tied to the query,
+        // so to avoid immediate garbage collection of the still
+        // empty query, we wait with activating timeouts until
+        // the prefetch is done
+        query.activateTimeouts()
+      }
     }
   }
 
@@ -331,11 +337,13 @@ export class QueryCache {
       return
     }
 
-    this.buildQuery<TResult, TError>(queryKey, {
+    const newQuery = this.buildQuery<TResult, TError>(queryKey, {
       initialStale: typeof config?.staleTime === 'undefined',
       initialData: functionalUpdate(updater, undefined),
       ...config,
     })
+
+    newQuery.activateTimeouts()
   }
 }
 

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -204,6 +204,8 @@ export class QueryObserver<TResult, TError> {
       return false
     }
 
+    newQuery.activateTimeouts()
+
     this.previousResult = this.currentResult
     this.currentQuery = newQuery
     this.currentResult = this.createResult()

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -813,7 +813,10 @@ describe('useQuery', () => {
     queryFn.mockImplementation(() => 'data')
 
     const prefetchQueryFn = jest.fn()
-    prefetchQueryFn.mockImplementation(() => 'not yet...')
+    prefetchQueryFn.mockImplementation(async () => {
+      await sleep(10)
+      return 'not yet...'
+    })
 
     await queryCache.prefetchQuery(key, prefetchQueryFn, {
       staleTime: 1000,
@@ -822,7 +825,9 @@ describe('useQuery', () => {
     await sleep(0)
 
     function Page() {
-      useQuery(key, queryFn)
+      useQuery(key, queryFn, {
+        staleTime: 1000,
+      })
       return null
     }
 


### PR DESCRIPTION
This PR refactors internals, specifically how `scheduleStaleTimeout` and `scheduleGarbageCollection` works behind the scenes, but leaves the documented public API unaffected. An earlier version was begun in #728, but has been fleshed out here and made sense as it's own PR.

The main goal is to remove scheduling of timeouts from the constructor of Query and instead let the consumer creating a new Query mark when timeouts are ready to be scheduled. This is needed to implement hydration, but will also make it easier to remove scheduling of timeouts from the render-phase in `useBaseQuery` as a next step.

* Remove scheduling timeouts from `constructor`
* Require explicit timeout activation via new `query.activateTimeouts()`
  - This only applies internally and specifically anyone using `buildQuery`. This is an undocumented API, so should be okay to change?
* Refactor all internal code to use `activateTimeouts`
* Rename schedule(GC/StaleTimeout) to rescheduleX
* Make reschedule-methods do the right thing based on query state
  - Previously we relied on these methods being called only at the correct times, now they can be called safely at any time
  - In a sense, this refactor mirrors how state and effects work in React, they "sync the timeout-sideeffects to what the current state is"
  - This gathers all the logic for stale/GC in their respective functions instead of being spread out
* Stale timeout is now based on updatedAt
  - Besides being necessary for the "reschedule"-approach, this is also necessary for hydration.
  - This could schedule queries to be stale a few ms earlier than previously (equivalent to execution time between `updatedAt` is set to when the timeout is scheduled, which is a sync process). Docs makes no promises about exact details here so this should be fine since the meaning of `staleTime` is preserved.

All tests are passing, I'm open to suggestions for adding new ones if there is something we need to verify further.

I'm not sure about the naming of `activateTimeouts()`, it could also be a more generic `initialize()` that could contain any future side effects for setting up queries. It could also be just `rescheduleTimeouts()` which would reflect that it actually schedules those timeouts and that it's is fine to use repeatedly, but that would loose the pretty important semantics that no timeouts will be scheduled until this function is called for the first time.

This is just an undocumented internal name though and easy to change, where it's used now I think `activateTimeouts()` makes sense, but I'm very open to suggestions. 😄 