### PR TITLE
feat: determine staleness locally instead of globally

### DIFF
--- a/docs/src/pages/docs/comparison.md
+++ b/docs/src/pages/docs/comparison.md
@@ -19,6 +19,7 @@ Feature/Capability Key:
 | Supported Query Keys                         | JSON                                   | JSON                       | GraphQL Query                       |
 | Query Key Change Detection                   | Deep Compare (Serialization)           | Referential Equality (===) | Deep Compare (Serialization)        |
 | Query Data Memoization Level                 | Query + Structural Sharing             | Query                      | Query + Entity + Structural Sharing |
+| Stale While Revalidate                       | Server-Side + Client-Side              | Server-Side                | None                                |
 | Bundle Size                                  | [![][bp-react-query]][bpl-react-query] | [![][bp-swr]][bpl-swr]     | [![][bp-apollo]][bpl-apollo]        |
 | Queries                                      | ✅                                     | ✅                         | ✅                                  |
 | Caching                                      | ✅                                     | ✅                         | ✅                                  |

--- a/src/hydration/hydration.ts
+++ b/src/hydration/hydration.ts
@@ -1,10 +1,9 @@
-import { DEFAULT_STALE_TIME, DEFAULT_CACHE_TIME } from '../core/config'
+import { DEFAULT_CACHE_TIME } from '../core/config'
 
 import type { Query, QueryCache, QueryKey, QueryConfig } from 'react-query'
 
 export interface DehydratedQueryConfig {
   queryKey: QueryKey
-  staleTime?: number
   cacheTime?: number
   initialData?: unknown
 }
@@ -41,9 +40,6 @@ function dehydrateQuery<TResult, TError = unknown>(
   // in the html-payload, but not consume it on the initial render.
   // We still schedule stale and garbage collection right away, which means
   // we need to specifically include staleTime and cacheTime in dehydration.
-  if (query.config.staleTime !== DEFAULT_STALE_TIME) {
-    dehydratedQuery.config.staleTime = query.config.staleTime
-  }
   if (query.config.cacheTime !== DEFAULT_CACHE_TIME) {
     dehydratedQuery.config.cacheTime = query.config.cacheTime
   }
@@ -93,6 +89,5 @@ export function hydrate<TResult>(
 
     const query = queryCache.buildQuery(queryKey, queryConfig)
     query.state.updatedAt = dehydratedQuery.updatedAt
-    query.activateGarbageCollectionTimeout()
   }
 }

--- a/src/hydration/tests/react.test.tsx
+++ b/src/hydration/tests/react.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
+
 import {
   ReactQueryCacheProvider as OriginalCacheProvider,
   makeQueryCache,
   useQuery,
 } from '../..'
 import { dehydrate, useHydrate, ReactQueryCacheProvider } from '../'
+import { waitForMs } from '../../react/tests/utils'
 
 describe('React hydration', () => {
   const fetchData: (value: string) => Promise<string> = value =>
@@ -37,6 +39,7 @@ describe('React hydration', () => {
 
       const rendered = render(<Page />)
 
+      await waitForMs(10)
       rendered.getByText('string')
     })
 
@@ -60,12 +63,8 @@ describe('React hydration', () => {
         </OriginalCacheProvider>
       )
 
+      await waitForMs(10)
       rendered.getByText('string')
-      expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(false)
-      await waitFor(() =>
-        expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(true)
-      )
-
       clientQueryCache.clear({ notify: false })
     })
   })
@@ -93,11 +92,8 @@ describe('React hydration', () => {
         </ReactQueryCacheProvider>
       )
 
+      await waitForMs(10)
       rendered.getByText('string')
-      expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(false)
-      await waitFor(() =>
-        expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(true)
-      )
 
       const intermediateCache = makeQueryCache()
       await intermediateCache.prefetchQuery('string', () =>
@@ -119,17 +115,10 @@ describe('React hydration', () => {
 
       // Existing query data should not be overwritten,
       // so this should still be the original data
+      await waitForMs(10)
       rendered.getByText('string')
       // But new query data should be available immediately
       rendered.getByText('added string')
-      expect(clientQueryCache.getQuery('added string')?.state.isStale).toBe(
-        false
-      )
-      await waitFor(() =>
-        expect(clientQueryCache.getQuery('added string')?.state.isStale).toBe(
-          true
-        )
-      )
 
       clientQueryCache.clear({ notify: false })
     })
@@ -156,11 +145,8 @@ describe('React hydration', () => {
         </ReactQueryCacheProvider>
       )
 
+      await waitForMs(10)
       rendered.getByText('string')
-      expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(false)
-      await waitFor(() =>
-        expect(clientQueryCache.getQuery('string')?.state.isStale).toBe(true)
-      )
 
       const newClientQueryCache = makeQueryCache()
 
@@ -173,11 +159,8 @@ describe('React hydration', () => {
         </ReactQueryCacheProvider>
       )
 
+      await waitForMs(10)
       rendered.getByText('string')
-      expect(newClientQueryCache.getQuery('string')?.state.isStale).toBe(false)
-      await waitFor(() =>
-        expect(newClientQueryCache.getQuery('string')?.state.isStale).toBe(true)
-      )
 
       clientQueryCache.clear({ notify: false })
       newClientQueryCache.clear({ notify: false })

--- a/src/react/tests/utils.tsx
+++ b/src/react/tests/utils.tsx
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/react'
+
 let queryKeyCount = 0
 
 export function mockVisibilityState(value: string) {
@@ -28,6 +30,15 @@ export function queryKey(): string {
 export function sleep(timeout: number): Promise<void> {
   return new Promise((resolve, _reject) => {
     setTimeout(resolve, timeout)
+  })
+}
+
+export function waitForMs(ms: number) {
+  const end = Date.now() + ms
+  return waitFor(() => {
+    if (Date.now() < end) {
+      throw new Error('Time not elapsed yet')
+    }
   })
 }
 


### PR DESCRIPTION
This MR allows users to define different stale times for different situations. Instead of marking a whole query as stale, the staleness of a query is determined when consuming the query. The rationale for this can be found here: https://github.com/tannerlinsley/react-query/discussions/770#discussioncomment-42352 . This also resolves some of the confusion about what happens if different hooks define different stale times.