### PR TITLE
fix: always use config from last query execution

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -7,6 +7,7 @@ import type {
   FetchMoreOptions,
   RefetchOptions,
 } from './query'
+import type { QueryCache } from './queryCache'
 
 export type UpdateListener<TResult, TError> = (
   result: QueryResult<TResult, TError>
@@ -15,6 +16,7 @@ export type UpdateListener<TResult, TError> = (
 export class QueryObserver<TResult, TError> {
   config: QueryObserverConfig<TResult, TError>
 
+  private queryCache: QueryCache
   private currentQuery!: Query<TResult, TError>
   private currentResult!: QueryResult<TResult, TError>
   private previousResult?: QueryResult<TResult, TError>
@@ -25,6 +27,7 @@ export class QueryObserver<TResult, TError> {
 
   constructor(config: QueryObserverConfig<TResult, TError>) {
     this.config = config
+    this.queryCache = config.queryCache!
 
     // Bind exposed methods
     this.clear = this.clear.bind(this)
@@ -106,22 +109,19 @@ export class QueryObserver<TResult, TError> {
   }
 
   async refetch(options?: RefetchOptions): Promise<TResult | undefined> {
-    this.currentQuery.updateConfig(this.config)
-    return this.currentQuery.refetch(options)
+    return this.currentQuery.refetch(options, this.config)
   }
 
   async fetchMore(
     fetchMoreVariable?: unknown,
     options?: FetchMoreOptions
   ): Promise<TResult | undefined> {
-    this.currentQuery.updateConfig(this.config)
-    return this.currentQuery.fetchMore(fetchMoreVariable, options)
+    return this.currentQuery.fetchMore(fetchMoreVariable, options, this.config)
   }
 
   async fetch(): Promise<TResult | undefined> {
-    this.currentQuery.updateConfig(this.config)
     try {
-      return await this.currentQuery.fetch()
+      return await this.currentQuery.fetch(undefined, this.config)
     } catch (error) {
       return undefined
     }
@@ -281,7 +281,7 @@ export class QueryObserver<TResult, TError> {
       ? { ...this.config, initialData: undefined }
       : this.config
 
-    const newQuery = config.queryCache!.buildQuery(config.queryKey, config)
+    const newQuery = this.queryCache.buildQuery(config.queryKey, config)
 
     if (newQuery === prevQuery) {
       return false

--- a/src/core/tests/queryCache.test.tsx
+++ b/src/core/tests/queryCache.test.tsx
@@ -267,7 +267,6 @@ describe('queryCache', () => {
     })
     const query = defaultQueryCache.getQuery(key)!
     const instance = query.subscribe()
-    instance.updateConfig(query.config)
     // @ts-expect-error
     expect(instance.refetchIntervalId).not.toBeUndefined()
     instance.unsubscribe()
@@ -360,6 +359,21 @@ describe('queryCache', () => {
       expect(subscriber).toHaveBeenCalledWith(queryCache, query)
 
       unsubscribe()
+    })
+
+    test('query should use the longest cache time it has seen', async () => {
+      const key = queryKey()
+      await defaultQueryCache.prefetchQuery(key, () => 'data', {
+        cacheTime: 100,
+      })
+      await defaultQueryCache.prefetchQuery(key, () => 'data', {
+        cacheTime: 200,
+      })
+      await defaultQueryCache.prefetchQuery(key, () => 'data', {
+        cacheTime: 10,
+      })
+      const query = defaultQueryCache.getQuery(key)!
+      expect(query.cacheTime).toBe(200)
     })
 
     it('should continue retry after focus regain and resolve all promises', async () => {

--- a/src/hydration/hydration.ts
+++ b/src/hydration/hydration.ts
@@ -40,8 +40,8 @@ function dehydrateQuery<TResult, TError = unknown>(
   // in the html-payload, but not consume it on the initial render.
   // We still schedule stale and garbage collection right away, which means
   // we need to specifically include staleTime and cacheTime in dehydration.
-  if (query.config.cacheTime !== DEFAULT_CACHE_TIME) {
-    dehydratedQuery.config.cacheTime = query.config.cacheTime
+  if (query.cacheTime !== DEFAULT_CACHE_TIME) {
+    dehydratedQuery.config.cacheTime = query.cacheTime
   }
   if (query.state.data !== undefined) {
     dehydratedQuery.config.initialData = query.state.data
@@ -62,7 +62,7 @@ export function dehydrate(
   const dehydratedState: DehydratedState = {
     queries: [],
   }
-  for (const query of Object.values(queryCache.queries)) {
+  for (const query of queryCache.getQueries()) {
     if (shouldDehydrate(query)) {
       dehydratedState.queries.push(dehydrateQuery(query))
     }

--- a/src/react/tests/ssr.test.tsx
+++ b/src/react/tests/ssr.test.tsx
@@ -96,7 +96,7 @@ describe('Server Side Rendering', () => {
 
       renderToString(<Page />)
 
-      expect(queryCache.queries).toEqual({})
+      expect(queryCache.getQueries().length).toEqual(0)
     })
 
     it('should not add prefetched data to the cache', async () => {
@@ -209,7 +209,9 @@ describe('Server Side Rendering', () => {
         </ReactQueryCacheProvider>
       )
 
-      expect(Object.keys(queryCache.queries)).toEqual([`["${key}",1]`])
+      const keys = queryCache.getQueries().map(query => query.queryHash)
+
+      expect(keys).toEqual([`["${key}",1]`])
     })
 
     it('should not call setTimeout', async () => {

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -577,6 +577,30 @@ describe('useQuery', () => {
     rendered.getByText('Second Status: success')
   })
 
+  it('should not override query configuration on render', async () => {
+    const key = queryKey()
+
+    const queryFn1 = async () => {
+      await sleep(10)
+      return 'data1'
+    }
+
+    const queryFn2 = async () => {
+      await sleep(10)
+      return 'data2'
+    }
+
+    function Page() {
+      useQuery(key, queryFn1)
+      useQuery(key, queryFn2)
+      return null
+    }
+
+    render(<Page />)
+
+    expect(queryCache.getQuery(key)!.config.queryFn).toBe(queryFn1)
+  })
+
   // See https://github.com/tannerlinsley/react-query/issues/170
   it('should start with status idle if enabled is false', async () => {
     const key1 = queryKey()


### PR DESCRIPTION
Currently the query configuration is dependent on the order in which hooks are rendered and this could result in unexpected behaviour. This MR will make sure the query configuration is only changed on execution. Related to https://github.com/tannerlinsley/react-query/discussions/932