### PR TITLE
fix: use hook config on refocus or reconnect

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -231,33 +231,22 @@ export class Query<TResult, TError> {
     )
   }
 
-  onWindowFocus(): void {
-    if (
-      this.observers.some(
-        observer =>
-          observer.isStale() &&
-          observer.config.enabled &&
-          observer.config.refetchOnWindowFocus
-      )
-    ) {
-      this.fetch().catch(noop)
+  onInteraction(type: 'focus' | 'online'): void {
+    // Execute the first observer which is enabled,
+    // stale and wants to refetch on this interaction.
+    const observer = this.observers.find(
+      observer =>
+        observer.isStale() &&
+        observer.config.enabled &&
+        ((observer.config.refetchOnWindowFocus && type === 'focus') ||
+          (observer.config.refetchOnReconnect && type === 'online'))
+    )
+
+    if (observer) {
+      observer.fetch().catch(noop)
     }
 
-    this.continue()
-  }
-
-  onOnline(): void {
-    if (
-      this.observers.some(
-        observer =>
-          observer.isStale() &&
-          observer.config.enabled &&
-          observer.config.refetchOnReconnect
-      )
-    ) {
-      this.fetch().catch(noop)
-    }
-
+    // Continue any paused fetch
     this.continue()
   }
 

--- a/src/core/queryCache.ts
+++ b/src/core/queryCache.ts
@@ -354,15 +354,11 @@ export function makeQueryCache(config?: QueryCacheConfig) {
   return new QueryCache(config)
 }
 
-export function onVisibilityOrOnlineChange(isOnlineChange: boolean) {
+export function onVisibilityOrOnlineChange(type: 'focus' | 'online') {
   if (isDocumentVisible() && isOnline()) {
     queryCaches.forEach(queryCache => {
       queryCache.getQueries().forEach(query => {
-        if (isOnlineChange) {
-          query.onOnline()
-        } else {
-          query.onWindowFocus()
-        }
+        query.onInteraction(type)
       })
     })
   }

--- a/src/core/setFocusHandler.ts
+++ b/src/core/setFocusHandler.ts
@@ -2,7 +2,7 @@ import { createSetHandler, isServer } from './utils'
 import { onVisibilityOrOnlineChange } from './queryCache'
 
 export const setFocusHandler = createSetHandler(() =>
-  onVisibilityOrOnlineChange(false)
+  onVisibilityOrOnlineChange('focus')
 )
 
 setFocusHandler(handleFocus => {

--- a/src/core/setOnlineHandler.ts
+++ b/src/core/setOnlineHandler.ts
@@ -2,7 +2,7 @@ import { createSetHandler, isServer } from './utils'
 import { onVisibilityOrOnlineChange } from './queryCache'
 
 export const setOnlineHandler = createSetHandler(() =>
-  onVisibilityOrOnlineChange(true)
+  onVisibilityOrOnlineChange('online')
 )
 
 setOnlineHandler(handleOnline => {


### PR DESCRIPTION
On window refocus or reconnect, trigger the first observer which indicates it should be refetched.