### PR TITLE
fix: typo in useQuery.test

### DIFF
--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -29,7 +29,7 @@ describe('useQuery', () => {
       expectType<string | undefined>(fromQueryFn.data)
       expectType<unknown>(fromQueryFn.error)
 
-      // it should be possible to specify the error type
+      // it should be possible to specify the result type
       const withResult = useQuery<string>(key, () => 'test')
       expectType<string | undefined>(withResult.data)
       expectType<unknown | null>(withResult.error)


### PR DESCRIPTION
I spotted a typo in a comment when reading through the tests.