### PR TITLE
fix(hydration): overwrite the existing data in the cache if hydrated data is newer

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -65,6 +65,10 @@ const enum ActionType {
   Error,
 }
 
+interface SetDataOptions {
+  updatedAt?: number
+}
+
 interface FailedAction {
   type: ActionType.Failed
 }
@@ -78,6 +82,7 @@ interface SuccessAction<TResult> {
   type: ActionType.Success
   data: TResult | undefined
   canFetchMore?: boolean
+  updatedAt?: number
 }
 
 interface ErrorAction<TError> {
@@ -175,7 +180,10 @@ export class Query<TResult, TError> {
     }
   }
 
-  setData(updater: Updater<TResult | undefined, TResult>): void {
+  setData(
+    updater: Updater<TResult | undefined, TResult>,
+    options?: SetDataOptions
+  ): void {
     const prevData = this.state.data
 
     // Get the new data
@@ -199,6 +207,7 @@ export class Query<TResult, TError> {
       type: ActionType.Success,
       data,
       canFetchMore,
+      updatedAt: options?.updatedAt,
     })
   }
 
@@ -630,7 +639,7 @@ export function queryReducer<TResult, TError>(
         isFetching: false,
         isFetchingMore: false,
         canFetchMore: action.canFetchMore,
-        updatedAt: Date.now(),
+        updatedAt: action.updatedAt ?? Date.now(),
         failureCount: 0,
       }
     case ActionType.Error:

--- a/src/hydration/tests/react.test.tsx
+++ b/src/hydration/tests/react.test.tsx
@@ -92,7 +92,7 @@ describe('React hydration', () => {
 
       const intermediateCache = makeQueryCache()
       await intermediateCache.prefetchQuery('string', () =>
-        dataQuery('should not change')
+        dataQuery('should change')
       )
       await intermediateCache.prefetchQuery('added string', dataQuery)
       const dehydrated = dehydrate(intermediateCache)
@@ -107,11 +107,11 @@ describe('React hydration', () => {
         </ReactQueryCacheProvider>
       )
 
-      // Existing query data should not be overwritten,
-      // so this should still be the original data
+      // Existing query data should be overwritten if older,
+      // so this should have changed
       await waitForMs(10)
-      rendered.getByText('string')
-      // But new query data should be available immediately
+      rendered.getByText('should change')
+      // New query data should be available immediately
       rendered.getByText('added string')
 
       clientQueryCache.clear({ notify: false })


### PR DESCRIPTION
Fixes #951 

This makes it so hydrating queries that have newer data according to `updatedAt` will set this new data to the existing query in the cache (with the correct `updatedAt`).

This PR also moves some internal stuff around in hydration as well as changes the shape of the hydration payload. Hydrated queries are no longer set with `initialData`, instead `query.setData` with the new internal `updatedAt`-option is used.