### PR TITLE
feat: add reset error boundary component

### DIFF
--- a/docs/src/pages/docs/guides/suspense.md
+++ b/docs/src/pages/docs/guides/suspense.md
@@ -43,23 +43,57 @@ In addition to queries behaving differently in suspense mode, mutations also beh
 
 ## Resetting Error Boundaries
 
-Whether you are using **suspense** or **useErrorBoundaries** in your queries, you will need to know how to use the `queryCache.resetErrorBoundaries` function to let queries know that you want them to try again when you render them again.
+Whether you are using **suspense** or **useErrorBoundaries** in your queries, you will need a way to let queries know that you want to try again when re-rendering after some error occured.
 
-How you trigger this function is up to you, but the most common use case is to do it in something like `react-error-boundary`'s `onReset` callback:
+Query errors can be reset with the `ReactQueryErrorResetBoundary` component or with the `useErrorResetBoundary` hook.
+
+When using the component it will reset any query errors within the boundaries of the component:
 
 ```js
-import { queryCache } from "react-query";
-import { ErrorBoundary } from "react-error-boundary";
+import { ReactQueryErrorResetBoundary } from 'react-query'
+import { ErrorBoundary } from 'react-error-boundary'
 
-<ErrorBoundary
-  onReset={() => queryCache.resetErrorBoundaries()}
-  fallbackRender={({ error, resetErrorBoundary }) => (
-    <div>
-      There was an error!
-      <Button onClick={() => resetErrorBoundary()}>Try again</Button>
-    </div>
-  )}
->
+const App: React.FC = () => (
+  <ReactQueryErrorResetBoundary>
+    {({ reset }) => (
+      <ErrorBoundary
+        onReset={reset}
+        fallbackRender={({ resetErrorBoundary }) => (
+          <div>
+            There was an error!
+            <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
+    )}
+  </ReactQueryErrorResetBoundary>
+)
+```
+
+When using the hook it will reset any query errors within the closest `ReactQueryErrorResetBoundary`. If there is no boundary defined it will reset them globally:
+
+```js
+import { useErrorResetBoundary } from 'react-query'
+import { ErrorBoundary } from 'react-error-boundary'
+
+const App: React.FC = () => {
+  const { reset } = useErrorResetBoundary()
+  return (
+    <ErrorBoundary
+      onReset={reset}
+      fallbackRender={({ resetErrorBoundary }) => (
+        <div>
+          There was an error!
+          <Button onClick={() => resetErrorBoundary()}>Try again</Button>
+        </div>
+      )}
+    >
+      <Page />
+    </ErrorBoundary>
+  )
+}
 ```
 
 ## Fetch-on-render vs Render-as-you-fetch

--- a/src/react/ReactQueryErrorResetBoundary.tsx
+++ b/src/react/ReactQueryErrorResetBoundary.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+// CONTEXT
+
+interface ReactQueryErrorResetBoundaryValue {
+  clearReset: () => void
+  isReset: () => boolean
+  reset: () => void
+}
+
+function createValue(): ReactQueryErrorResetBoundaryValue {
+  let isReset = true
+  return {
+    clearReset: () => {
+      isReset = false
+    },
+    reset: () => {
+      isReset = true
+    },
+    isReset: () => {
+      return isReset
+    },
+  }
+}
+
+const context = React.createContext(createValue())
+
+// HOOK
+
+export const useErrorResetBoundary = () => React.useContext(context)
+
+// COMPONENT
+
+export interface ReactQueryErrorResetBoundaryProps {
+  children:
+    | ((value: ReactQueryErrorResetBoundaryValue) => React.ReactNode)
+    | React.ReactNode
+}
+
+export const ReactQueryErrorResetBoundary: React.FC<ReactQueryErrorResetBoundaryProps> = ({
+  children,
+}) => {
+  const value = React.useMemo(() => createValue(), [])
+  return (
+    <context.Provider value={value}>
+      {typeof children === 'function'
+        ? (children as Function)(value)
+        : children}
+    </context.Provider>
+  )
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -3,6 +3,10 @@ export {
   useQueryCache,
 } from './ReactQueryCacheProvider'
 export { ReactQueryConfigProvider } from './ReactQueryConfigProvider'
+export {
+  ReactQueryErrorResetBoundary,
+  useErrorResetBoundary,
+} from './ReactQueryErrorResetBoundary'
 export { useIsFetching } from './useIsFetching'
 export { useMutation } from './useMutation'
 export { useQuery } from './useQuery'
@@ -15,3 +19,4 @@ export type { UseInfiniteQueryObjectConfig } from './useInfiniteQuery'
 export type { UsePaginatedQueryObjectConfig } from './usePaginatedQuery'
 export type { ReactQueryCacheProviderProps } from './ReactQueryCacheProvider'
 export type { ReactQueryConfigProviderProps } from './ReactQueryConfigProvider'
+export type { ReactQueryErrorResetBoundaryProps } from './ReactQueryErrorResetBoundary'


### PR DESCRIPTION
Because error boundaries are only applicable to a certain a tree, I think it would be good if the error reset would also only be applicable to that specific tree.

The `ReactQueryResetErrorBoundary` component enables this functionality, while allowing users to keep their own error boundary component. This does mean users will need to wrap their queries in two boundaries. We could streamline this by providing a `ReactQueryErrorBoundary` component similar to `react-error-boundary`. But maybe there are arguments against this?

This change should be backwards compatible and would allow us to remove `queryCache.resetErrorBoundaries()` and `query.state.throwInErrorBoundary` in v3 to make the core less knowledgable about React.