### PR TITLE
Remove storing the return value of queryCache.removeQueries

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -549,7 +549,7 @@ This function does not return anything
 The `removeQueries` method can be used to remove queries from the cache based on their query keys or any other functionally accessible property/state of the query.
 
 ```js
-const queries = queryCache.removeQueries(queryKeyOrPredicateFn, {
+queryCache.removeQueries(queryKeyOrPredicateFn, {
   exact,
 })
 ```


### PR DESCRIPTION
Hi,

I removed storing the return value of `queryCache.removeQueries` as it doesn't return anything.

BTW, is it an expected behavior that `queryCache.removeQueries` only removes `inactive` queries?

Thanks.