### PR TITLE
fix: query should try and throw again after error boundary reset

### DIFF
--- a/src/react/tests/ReactQueryResetErrorBoundary.test.tsx
+++ b/src/react/tests/ReactQueryResetErrorBoundary.test.tsx
@@ -63,4 +63,61 @@ describe('ReactQueryResetErrorBoundary', () => {
 
     consoleMock.mockRestore()
   })
+
+  it('should throw again on error after the reset error boundary has been reset', async () => {
+    const key = queryKey()
+    const consoleMock = mockConsoleError()
+    let fetchCount = 0
+
+    function Page() {
+      const { data } = useQuery(
+        key,
+        async () => {
+          fetchCount++
+          await sleep(10)
+          throw new Error('Error')
+        },
+        {
+          retry: false,
+          useErrorBoundary: true,
+        }
+      )
+      return <div>{data}</div>
+    }
+
+    const rendered = render(
+      <ReactQueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            onReset={reset}
+            fallbackRender={({ resetErrorBoundary }) => (
+              <div>
+                <div>error boundary</div>
+                <button
+                  onClick={() => {
+                    resetErrorBoundary()
+                  }}
+                >
+                  retry
+                </button>
+              </div>
+            )}
+          >
+            <Page />
+          </ErrorBoundary>
+        )}
+      </ReactQueryErrorResetBoundary>
+    )
+
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('retry'))
+    fireEvent.click(rendered.getByText('retry'))
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('retry'))
+    fireEvent.click(rendered.getByText('retry'))
+    await waitFor(() => rendered.getByText('error boundary'))
+    expect(fetchCount).toBe(3)
+
+    consoleMock.mockRestore()
+  })
 })

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -33,15 +33,14 @@ export function useBaseQuery<TResult, TError>(
   observerRef.current = observer
 
   // Subscribe to the observer
-  React.useEffect(
-    () =>
-      observer.subscribe(() => {
-        if (isMounted()) {
-          rerender()
-        }
-      }),
-    [isMounted, observer, rerender]
-  )
+  React.useEffect(() => {
+    errorResetBoundary.clearReset()
+    return observer.subscribe(() => {
+      if (isMounted()) {
+        rerender()
+      }
+    })
+  }, [isMounted, observer, rerender, errorResetBoundary])
 
   // Update config
   if (!firstRender) {


### PR DESCRIPTION
Fixes https://github.com/tannerlinsley/react-query/issues/1053