### PR TITLE
docs: fix `user.id` access in case user is null

### DIFF
--- a/docs/src/pages/docs/guides/queries.md
+++ b/docs/src/pages/docs/guides/queries.md
@@ -200,7 +200,7 @@ const { data: user } = useQuery(['user', email], getUserByEmail)
 
 // Then get the user's projects
 const { isIdle, data: projects } = useQuery(
-  ['projects', user.id],
+  ['projects', user?.id],
   getProjectsByUser,
   {
     // `user` would be `null` at first (falsy),


### PR DESCRIPTION
We need `user?.id` instead of `user.id` in order to correctly handle the `null` case.