### PR TITLE
Remove storing the return value of queryCache.cancelQueries

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -583,7 +583,7 @@ The `cancelQueries` method can be used to cancel outgoing queries based on their
 This is most useful when performing optimistic updates since you will likely need to cancel any outgoing query refetches so they don't clobber your optimistic update when they resolve.
 
 ```js
-const queries = queryCache.cancelQueries(queryKeyOrPredicateFn, {
+queryCache.cancelQueries(queryKeyOrPredicateFn, {
   exact,
 })
 ```


### PR DESCRIPTION
Removed storing the return value of `queryCache.cancelQueries` as it doesn't return anything.