### PR TITLE
docs: fix typo in Important Defaults

### DIFF
--- a/docs/src/pages/docs/guides/important-defaults.md
+++ b/docs/src/pages/docs/guides/important-defaults.md
@@ -20,6 +20,6 @@ Out of the box, React Query is configured with **aggressive but sane** defaults.
 
 > To change this, you can alter the default `retry` and `retryDelay` options for queries to something other than `3` and the default exponential backoff function.
 
-- Query results by default are **structurally shared to detect if data has actually changed** and if not, **the data reference remains unchanged** to better help with value stabilization with regards to useMemo and useCallback. If this concept sounds foreign, then don't worry about it! 99.9% of the time you will not need to disable this and it make your app more performant at zero cost to you.
+- Query results by default are **structurally shared to detect if data has actually changed** and if not, **the data reference remains unchanged** to better help with value stabilization with regards to useMemo and useCallback. If this concept sounds foreign, then don't worry about it! 99.9% of the time you will not need to disable this and it makes your app more performant at zero cost to you.
 
 > Structural sharing only works with JSON-compatible values, any other value types will always be considered as changed. If you are seeing performance issues because of large responses for example, you can disable this feature with the `config.structuralSharing` flag. If you are dealing with non-JSON compatible values in your query responses and still want to detect if data has changed or not, you can define a data compare function with `config.isDataEqual`.


### PR DESCRIPTION
I was reading the docs and noticed this wasn't quite correct. I assume "it makes your app more performant" is what's intended here, but "it will make your app more performant" could work as well. 