### PR TITLE
refactor(types): expose types for `react-query/es/*`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
   },
   "main": "lib/index.js",
   "unpkg": "dist/react-query.development.js",
-  "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "types/*",
+        "types/*/index"
+      ]
+    }
+  },
   "module": "es/index.js",
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   },
   "main": "lib/index.js",
   "unpkg": "dist/react-query.development.js",
+  "types": "types/index.d.ts",
   "typesVersions": {
     "*": {
-      "*": [
+      "es/*": [
         "types/*",
-        "types/*/index"
+        "types/*/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
By using `typesVersions` instead of `types` pointing to a single `index` declaration file, we enable consumers of `react-query` to also import directly from nested files, like `react-query/core`. These files are de-facto importable, but TypeScript does not "see" them currently.

I understand that in regular React day to day usage, this is irrelevant (or potentially even undesirable), but I am currently working on building a `react-query` clone for Ember.js and would love to use the rock-solid `react-query/core` as a foundation for this.

For `react-query` v3 I'd like to suggest splitting out the `core` lib into a standalone package to make code-sharing easier. It could still reside in this repo by switching to a yarn/lerna monorepo.

Thank you for considering! 😊 