### PR TITLE
docs(installation): Add missing links

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -21,7 +21,7 @@ yarn add react-query
 
 React Query is compatible with React v16.8+ and works with ReactDOM and React Native.
 
-> Wanna give it a spin before you download? Try out the [simple]() or [basic]() examples!
+> Wanna give it a spin before you download? Try out the [simple](/docs/examples/simple) or [basic](/docs/examples/basic) examples!
 
 ### CDN
 


### PR DESCRIPTION
Noticed that simple and basic links were missing from the installation code block.

This also revealed a css usability issue regarding anchor tags in `blockquote` elements. As the colors of the `a` are being inherited. Currently that would be gray, `:visited `is unaffected.