### PR TITLE
use discriminating union for query result type

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -274,7 +274,7 @@ export class QueryObserver<TResult, TError> {
       refetch: this.refetch,
       remove: this.remove,
       updatedAt,
-    }
+    } as QueryResult<TResult, TError>
   }
 
   private updateQuery(): void {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -327,16 +327,50 @@ export type MutationResultPair<TResult, TError, TVariables, TSnapshot> = [
   MutationResult<TResult, TError>
 ]
 
-export interface MutationResult<TResult, TError = unknown> {
-  status: QueryStatus
-  data: TResult | undefined
-  error: TError | null
-  isIdle: boolean
-  isLoading: boolean
-  isSuccess: boolean
-  isError: boolean
+interface MutationResultCommon {
   reset: () => void
 }
+interface MutationResultIdle extends MutationResultCommon {
+  status: QueryStatus.Idle
+  data?: undefined
+  error?: null
+  isIdle: true
+  isLoading: false
+  isSuccess: false
+  isError: false
+}
+interface MutationResultLoading extends MutationResultCommon {
+  status: QueryStatus.Loading
+  data?: undefined
+  error?: null
+  isIdle: false
+  isLoading: true
+  isSuccess: false
+  isError: false
+}
+interface MutationResultSuccess<TResult> extends MutationResultCommon {
+  status: QueryStatus
+  data: TResult
+  error?: null
+  isIdle: false
+  isLoading: false
+  isSuccess: true
+  isError: false
+}
+interface MutationResultError<TError> extends MutationResultCommon {
+  status: QueryStatus
+  data?: undefined
+  error: TError
+  isIdle: false
+  isLoading: false
+  isSuccess: true
+  isError: false
+}
+export type MutationResult<TResult, TError = unknown> =
+  | MutationResultIdle
+  | MutationResultLoading
+  | MutationResultSuccess<TResult>
+  | MutationResultError<TError>
 
 export interface ReactQueryConfig<TResult = unknown, TError = unknown> {
   queries?: ReactQueryQueriesConfig<TResult, TError>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -185,44 +185,92 @@ export enum QueryStatus {
   Success = 'success',
 }
 
-export interface QueryResultBase<TResult, TError = unknown> {
+interface QueryResultBaseCommon<TResult> {
   canFetchMore: boolean | undefined
   clear: () => void
-  data: TResult | undefined
-  error: TError | null
   failureCount: number
   fetchMore: (
     fetchMoreVariable?: unknown,
     options?: FetchMoreOptions
   ) => Promise<TResult | undefined>
-  isError: boolean
   isFetched: boolean
   isFetchedAfterMount: boolean
   isFetching: boolean
   isFetchingMore?: IsFetchingMoreValue
-  isIdle: boolean
   isInitialData: boolean
-  isLoading: boolean
   isPreviousData: boolean
   isStale: boolean
-  isSuccess: boolean
   refetch: (options?: RefetchOptions) => Promise<TResult | undefined>
   remove: () => void
-  status: QueryStatus
   updatedAt: number
 }
 
-export interface QueryResult<TResult, TError = unknown>
-  extends QueryResultBase<TResult, TError> {}
+interface QueryResultBaseIdle<TResult> extends QueryResultBaseCommon<TResult> {
+  status: QueryStatus.Idle
+  isIdle: true
+  isLoading: false
+  isSuccess: false
+  isError: false
+  data?: undefined
+  error: null
+}
 
-export interface PaginatedQueryResult<TResult, TError = unknown>
-  extends QueryResultBase<TResult, TError> {
+interface QueryResultBaseLoading<TResult>
+  extends QueryResultBaseCommon<TResult> {
+  status: QueryStatus.Loading
+  isIdle: false
+  isLoading: true
+  isSuccess: false
+  isError: false
+  data?: undefined
+  error: null
+}
+
+interface QueryResultBaseSuccess<TResult>
+  extends QueryResultBaseCommon<TResult> {
+  status: QueryStatus.Success
+  isIdle: false
+  isLoading: false
+  isSuccess: true
+  isError: false
+  data: TResult
+  error: null
+}
+
+interface QueryResultBaseError<TResult, TError = unknown>
+  extends QueryResultBaseCommon<TResult> {
+  status: QueryStatus.Error
+  isIdle: false
+  isLoading: false
+  isSuccess: false
+  isError: true
+  data?: undefined
+  error: TError
+}
+
+export type QueryResultBase<TResult, TError = unknown> =
+  | QueryResultBaseIdle<TResult>
+  | QueryResultBaseLoading<TResult>
+  | QueryResultBaseSuccess<TResult>
+  | QueryResultBaseError<TResult, TError>
+
+export type QueryResult<TResult, TError = unknown> = QueryResultBase<
+  TResult,
+  TError
+>
+
+export type PaginatedQueryResult<TResult, TError = unknown> = QueryResultBase<
+  TResult,
+  TError
+> & {
   resolvedData: TResult | undefined
   latestData: TResult | undefined
 }
 
-export interface InfiniteQueryResult<TResult, TError = unknown>
-  extends QueryResultBase<TResult[], TError> {}
+export type InfiniteQueryResult<TResult, TError = unknown> = QueryResultBase<
+  TResult[],
+  TError
+>
 
 export interface MutateConfig<
   TResult,

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -199,10 +199,7 @@ export function useMutation<
     dispatch({ type: ActionType.Reset })
   }, [dispatch])
 
-  const result: MutationResult<TResult, TError> = {
-    ...state,
-    reset,
-  }
+  const result = { ...state, reset } as MutationResult<TResult, TError>
 
   return [mutate, result]
 }


### PR DESCRIPTION
This PR adds back discriminated union types, I don't know where they create overhead and why they were removed, but I would argue that they are one of the few things that bring real benefits when using typescript.

https://github.com/tannerlinsley/react-query/discussions/1102#discussioncomment-85980
https://github.com/tannerlinsley/react-query/discussions/922#discussioncomment-56912