### PR TITLE
Add eslint-config-prettier to devDependencies in custom-hooks example

### DIFF
--- a/examples/custom-hooks/README.md
+++ b/examples/custom-hooks/README.md
@@ -3,4 +3,4 @@
 To run this example:
 
 - `npm install` or `yarn`
-- `npm run start` or `yarn start`
+- `npm start` or `yarn start`

--- a/examples/custom-hooks/package.json
+++ b/examples/custom-hooks/package.json
@@ -20,7 +20,8 @@
     "@rescripts/cli": "^0.0.11",
     "@rescripts/rescript-use-babel-config": "^0.0.8",
     "@rescripts/rescript-use-eslint-config": "^0.0.9",
-    "babel-eslint": "10.0.1"
+    "babel-eslint": "10.0.1",
+    "eslint-config-prettier": "^6.12.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Fix failing build for the [custom-hooks](https://github.com/tannerlinsley/react-query/tree/master/examples/custom-hooks) example.

Making a fresh clone and running the custom-hooks example after `npm install` gives the following error:
![Selection_088](https://user-images.githubusercontent.com/29686866/94917938-2f1b6d00-04cf-11eb-8657-8c3591191d8f.png)

I've added the required package that fixes this build error.

Operating system: Ubuntu 20.04.1 LTS