### PR TITLE
feat: add support for plugins

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,5 +9,12 @@ export { hashQueryKey, isCancelledError, isError } from './utils'
 // Types
 export * from './types'
 export type { CancelledError } from './utils'
-export type { Query } from './query'
 export type { Logger } from './logger'
+export type {
+  OnMutateContext,
+  OnMutatePluginFunction,
+  OnQueryContext,
+  OnQueryPluginFunction,
+  Plugin,
+} from './plugins'
+export type { Query } from './query'

--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -1,0 +1,211 @@
+import { getLogger } from './logger'
+import { OnMutateContext, composeOnMutate } from './plugins'
+import { notifyManager } from './notifyManager'
+import { getStatusProps } from './utils'
+import type { MutateOptions, MutationOptions, MutationStatus } from './types'
+import type { MutationObserver } from './mutationObserver'
+import type { QueryClient } from './queryClient'
+
+// TYPES
+
+interface MutationConfig<TData, TError, TVariables, TContext> {
+  options: MutationOptions<TData, TError, TVariables, TContext>
+}
+
+export interface MutationState<TData, TError, TVariables> {
+  data: TData | undefined
+  error: TError | null
+  isError: boolean
+  isIdle: boolean
+  isLoading: boolean
+  isSuccess: boolean
+  status: MutationStatus
+  variables: TVariables | undefined
+}
+
+interface ResetAction {
+  type: 'reset'
+}
+
+interface LoadingAction<TVariables> {
+  type: 'loading'
+  variables: TVariables
+}
+
+interface SuccessAction<TData> {
+  type: 'success'
+  data: TData
+}
+
+interface ErrorAction<TError> {
+  type: 'error'
+  error: TError
+}
+
+type Action<TData, TError, TVariables> =
+  | ErrorAction<TError>
+  | LoadingAction<TVariables>
+  | ResetAction
+  | SuccessAction<TData>
+
+// CLASS
+
+export class Mutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+> {
+  state: MutationState<TData, TError, TVariables>
+  options!: MutationOptions<TData, TError, TVariables, TContext>
+
+  private observers: MutationObserver<TData, TError, TVariables, TContext>[]
+  private mutationId: number
+
+  constructor(config: MutationConfig<TData, TError, TVariables, TContext>) {
+    this.options = config.options
+    this.observers = []
+    this.state = getDefaultState()
+    this.mutationId = 0
+  }
+
+  setOptions(
+    options?: MutationOptions<TData, TError, TVariables, TContext>
+  ): void {
+    this.options = options || {}
+  }
+
+  private dispatch(action: Action<TData, TError, TVariables>): void {
+    this.state = reducer(this.state, action)
+    notifyManager.batch(() => {
+      this.observers.forEach(observer => {
+        observer.onMutationUpdate()
+      })
+    })
+  }
+
+  subscribeObserver(observer: MutationObserver<any, any, any, any>): void {
+    if (this.observers.indexOf(observer) === -1) {
+      this.observers.push(observer)
+    }
+  }
+
+  unsubscribeObserver(observer: MutationObserver<any, any, any, any>): void {
+    this.observers = this.observers.filter(x => x !== observer)
+  }
+
+  reset(): void {
+    this.dispatch({ type: 'reset' })
+  }
+
+  mutate(
+    client: QueryClient,
+    variables: TVariables,
+    options: MutateOptions<TData, TError, TVariables, TContext> = {}
+  ): Promise<TData> {
+    const mutationId = ++this.mutationId
+
+    let context: TContext | undefined
+    let data: TData
+
+    this.dispatch({ type: 'loading', variables })
+
+    return Promise.resolve()
+      .then(() => this.options.onMutate?.(variables))
+      .then(result => {
+        context = result
+      })
+      .then(() => {
+        const onMutateContext: OnMutateContext = {
+          client,
+          mutation: this,
+          options: this.options,
+          variables,
+        }
+
+        const fn = composeOnMutate<TData>(client.getPlugins())
+
+        return fn(onMutateContext, () =>
+          Promise.resolve(
+            this.options.mutationFn!(onMutateContext.variables as TVariables)
+          )
+        )
+      })
+      .then(result => {
+        data = result
+      })
+      .then(() => this.options.onSuccess?.(data, variables, context))
+      .then(() => this.options.onSettled?.(data, null, variables, context))
+      .then(() => options.onSuccess?.(data, variables, context))
+      .then(() => options.onSettled?.(data, null, variables, context))
+      .then(() => {
+        if (mutationId === this.mutationId) {
+          this.dispatch({ type: 'success', data })
+        }
+        return data
+      })
+      .catch(error => {
+        getLogger().error(error)
+        return Promise.resolve()
+          .then(() => this.options.onError?.(error, variables, context))
+          .then(() =>
+            this.options.onSettled?.(undefined, error, variables, context)
+          )
+          .then(() => options.onError?.(error, variables, context))
+          .then(() => options.onSettled?.(undefined, error, variables, context))
+          .then(() => {
+            if (mutationId === this.mutationId) {
+              this.dispatch({ type: 'error', error })
+            }
+            throw error
+          })
+      })
+  }
+}
+
+function getDefaultState<TData, TError, TVariables>(): MutationState<
+  TData,
+  TError,
+  TVariables
+> {
+  return {
+    ...getStatusProps('idle'),
+    data: undefined,
+    error: null,
+    variables: undefined,
+  }
+}
+
+function reducer<TData, TError, TVariables>(
+  state: MutationState<TData, TError, TVariables>,
+  action: Action<TData, TError, TVariables>
+): MutationState<TData, TError, TVariables> {
+  switch (action.type) {
+    case 'reset':
+      return getDefaultState()
+    case 'loading':
+      return {
+        ...state,
+        ...getStatusProps('loading'),
+        data: undefined,
+        error: null,
+        variables: action.variables,
+      }
+    case 'success':
+      return {
+        ...state,
+        ...getStatusProps('success'),
+        data: action.data,
+        error: null,
+      }
+    case 'error':
+      return {
+        ...state,
+        ...getStatusProps('error'),
+        data: undefined,
+        error: action.error,
+      }
+    default:
+      return state
+  }
+}

--- a/src/core/mutationObserver.ts
+++ b/src/core/mutationObserver.ts
@@ -1,0 +1,128 @@
+import { Mutation } from './mutation'
+import { notifyManager } from './notifyManager'
+import type { QueryClient } from './queryClient'
+import type {
+  MutateOptions,
+  MutationOptions,
+  MutationObserverResult,
+} from './types'
+
+// TYPES
+
+interface MutationObserverConfig<TData, TError, TVariables, TContext> {
+  client: QueryClient
+  options: MutationOptions<TData, TError, TVariables, TContext>
+}
+
+type MutationObserverListener<TData, TError, TVariables, TContext> = (
+  result: MutationObserverResult<TData, TError, TVariables, TContext>
+) => void
+
+// CLASS
+
+export class MutationObserver<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+> {
+  options: MutationOptions<TData, TError, TVariables, TContext>
+
+  private client: QueryClient
+  private currentResult!: MutationObserverResult<
+    TData,
+    TError,
+    TVariables,
+    TContext
+  >
+  private currentMutation: Mutation<TData, TError, TVariables, TContext>
+  private listeners: MutationObserverListener<
+    TData,
+    TError,
+    TVariables,
+    TContext
+  >[]
+
+  constructor(
+    config: MutationObserverConfig<TData, TError, TVariables, TContext>
+  ) {
+    this.client = config.client
+    this.options = config.options
+    this.listeners = []
+
+    // Bind exposed methods
+    this.mutate = this.mutate.bind(this)
+    this.reset = this.reset.bind(this)
+
+    // Subscribe to mutation
+    this.currentMutation = new Mutation(config)
+    this.currentMutation.subscribeObserver(this)
+
+    this.updateResult()
+  }
+
+  setOptions(options?: MutationOptions<TData, TError, TVariables, TContext>) {
+    this.options = this.client.defaultMutationOptions(options)
+  }
+
+  subscribe(
+    listener?: MutationObserverListener<TData, TError, TVariables, TContext>
+  ): () => void {
+    const callback = listener || (() => undefined)
+    this.listeners.push(callback)
+    return () => {
+      this.unsubscribe(callback)
+    }
+  }
+
+  private unsubscribe(
+    listener: MutationObserverListener<TData, TError, TVariables, TContext>
+  ): void {
+    this.listeners = this.listeners.filter(x => x !== listener)
+  }
+
+  onMutationUpdate(): void {
+    this.updateResult()
+    this.notify()
+  }
+
+  getCurrentResult(): MutationObserverResult<
+    TData,
+    TError,
+    TVariables,
+    TContext
+  > {
+    return this.currentResult
+  }
+
+  reset(): void {
+    this.currentMutation.reset()
+  }
+
+  mutate(
+    variables: TVariables,
+    options: MutateOptions<TData, TError, TVariables, TContext> = {}
+  ): Promise<TData> {
+    this.currentMutation.setOptions(this.options)
+    return this.currentMutation.mutate(this.client, variables, options)
+  }
+
+  private updateResult(): void {
+    this.currentResult = {
+      ...this.currentMutation.state,
+      mutate: this.mutate,
+      reset: this.reset,
+    }
+  }
+
+  private notify() {
+    const { currentResult } = this
+    notifyManager.batch(() => {
+      this.listeners.forEach(listener => {
+        notifyManager.schedule(() => {
+          listener(currentResult)
+        })
+      })
+    })
+  }
+}

--- a/src/core/plugins.ts
+++ b/src/core/plugins.ts
@@ -1,0 +1,82 @@
+import type { Mutation } from './mutation'
+import type { Query } from './query'
+import type { QueryClient } from './queryClient'
+import type { MutationOptions, QueryOptions } from './types'
+import { isDefined } from './utils'
+
+// TYPES
+
+export interface Plugin {
+  onQuery?: OnQueryPluginFunction
+  onMutate?: OnMutatePluginFunction
+}
+
+export type OnQueryPluginFunction = MiddlewareFunction<OnQueryContext>
+export type OnMutatePluginFunction = MiddlewareFunction<OnMutateContext>
+
+export interface OnQueryContext {
+  client: QueryClient
+  query: Query<any, any, any>
+  options: QueryOptions<any, any, any>
+  params: unknown[]
+}
+
+export interface OnMutateContext {
+  client: QueryClient
+  mutation: Mutation<any, any, any, any>
+  options: MutationOptions<any, any, any, any>
+  variables: unknown
+}
+
+type MiddlewareFunction<TContext, TResult = unknown> = (
+  context: TContext,
+  next: () => Promise<TResult>
+) => Promise<TResult>
+
+// FUNCTIONS
+
+export function composeOnQuery<TResult>(
+  plugins: Plugin[]
+): MiddlewareFunction<OnQueryContext, TResult> {
+  return composeMiddleware(
+    plugins
+      .map(x => x.onQuery as MiddlewareFunction<OnQueryContext, TResult>)
+      .filter(isDefined)
+  )
+}
+
+export function composeOnMutate<TResult>(
+  plugins: Plugin[]
+): MiddlewareFunction<OnMutateContext, TResult> {
+  return composeMiddleware(
+    plugins
+      .map(x => x.onMutate as MiddlewareFunction<OnMutateContext, TResult>)
+      .filter(isDefined)
+  )
+}
+
+function composeMiddleware<TContext, TResult>(
+  middlewares: MiddlewareFunction<TContext, TResult>[]
+): MiddlewareFunction<TContext, TResult> {
+  return (context, next) => {
+    let index = -1
+
+    function dispatch(i: number): Promise<TResult> {
+      if (i <= index) {
+        return Promise.reject(new Error('next() called multiple times'))
+      }
+
+      index = i
+
+      const fn = i === middlewares.length ? next : middlewares[i]
+
+      try {
+        return Promise.resolve(fn(context, () => dispatch(i + 1)))
+      } catch (error) {
+        return Promise.reject(error)
+      }
+    }
+
+    return dispatch(0)
+  }
+}

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -245,9 +245,6 @@ export class QueryObserver<
   fetch(
     fetchOptions?: FetchOptions
   ): Promise<QueryObserverResult<TData, TError>> {
-    if (!this.canFetch()) {
-      return this.getCurrentOrNextResult()
-    }
     const promise = this.getNextResult(fetchOptions)
     this.executeFetch(fetchOptions)
     return promise
@@ -260,15 +257,9 @@ export class QueryObserver<
   }
 
   private executeFetch(fetchOptions?: FetchOptions): void {
-    if (this.canFetch()) {
-      this.currentQuery.fetch(this.getQueryOptions(), fetchOptions).catch(noop)
-    }
-  }
-
-  private canFetch(): boolean {
-    return Boolean(
-      this.options.queryFn || this.currentQuery.defaultOptions?.queryFn
-    )
+    this.currentQuery
+      .fetch(this.client, this.getQueryOptions(), fetchOptions)
+      .catch(noop)
   }
 
   private updateStaleTimeout(): void {

--- a/src/core/tests/plugins.test.tsx
+++ b/src/core/tests/plugins.test.tsx
@@ -1,0 +1,216 @@
+import { mockConsoleError, queryKey } from '../../react/tests/utils'
+import { QueryCache, QueryClient } from '../..'
+
+describe('plugins', () => {
+  describe('onQuery', () => {
+    test('should be able to log a query', async () => {
+      const logs: unknown[][] = []
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async (context, next) => {
+              logs.push(context.params)
+              return next()
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      await client.fetchQueryData(key, () => key)
+      expect(logs).toEqual([[key]])
+    })
+
+    test('should be able to log a query result', async () => {
+      const logs: unknown[] = []
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async (_, next) => {
+              const result = await next()
+              logs.push(result)
+              return result
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      await client.fetchQueryData(key, () => key)
+      expect(logs).toEqual([key])
+    })
+
+    test('should be able to log a query error', async () => {
+      const consoleMock = mockConsoleError()
+      const logs: unknown[][] = []
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async (_, next) => {
+              try {
+                return await next()
+              } catch (error) {
+                logs.push(error)
+                throw error
+              }
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      try {
+        await client.fetchQueryData(key, () => {
+          throw new Error('oops')
+        })
+      } catch {}
+      expect(logs).toEqual([new Error('oops')])
+      consoleMock.mockRestore()
+    })
+
+    test('should be able to change query params', async () => {
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async (context, next) => {
+              context.params = ['new']
+              return next()
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      const data = await client.fetchQueryData(key, param1 => param1)
+      expect(data).toEqual('new')
+    })
+
+    test('should be able to short circuit with a result', async () => {
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async () => {
+              return 'different'
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      const data = await client.fetchQueryData(key, param1 => param1)
+      expect(data).toEqual('different')
+    })
+
+    test('should be able to short circuit with an error', async () => {
+      const consoleMock = mockConsoleError()
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: () => {
+              throw new Error('different')
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      let error
+      try {
+        await client.fetchQueryData(key, param1 => param1)
+      } catch (err) {
+        error = err
+      }
+      expect(error).toEqual(new Error('different'))
+      consoleMock.mockRestore()
+    })
+
+    test('should be able to chain middleware', async () => {
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onQuery: async (context, next) => {
+              context.params = [...context.params, 1]
+              return next()
+            },
+          },
+          {
+            onQuery: async (context, next) => {
+              context.params = [...context.params, 2]
+              return next()
+            },
+          },
+        ],
+      })
+      const key = queryKey()
+      const data = await client.fetchQueryData(
+        key,
+        (...params: any[]) => params
+      )
+      expect(data).toEqual([key, 1, 2])
+    })
+  })
+
+  describe('onMutate', () => {
+    test('should be able to log a mutation', async () => {
+      const logs: unknown[] = []
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onMutate: async (context, next) => {
+              logs.push(context.variables)
+              return next()
+            },
+          },
+        ],
+      })
+      await client.mutate((todo: string) => todo, 'todo')
+      expect(logs).toEqual(['todo'])
+    })
+
+    test('should be able to log a mutation result', async () => {
+      const logs: unknown[] = []
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onMutate: async (_, next) => {
+              const result = await next()
+              logs.push(result)
+              return result
+            },
+          },
+        ],
+      })
+      await client.mutate((_: string) => 'result', 'todo')
+      expect(logs).toEqual(['result'])
+    })
+
+    test('should be able to change the result', async () => {
+      const cache = new QueryCache()
+      const client = new QueryClient({
+        cache,
+        plugins: [
+          {
+            onMutate: async (_, next) => {
+              const result = await next()
+              return Promise.resolve(result + 'Adjusted')
+            },
+          },
+        ],
+      })
+      const result = await client.mutate((_: string) => 'result', 'todo')
+      expect(result).toEqual('resultAdjusted')
+    })
+  })
+})

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -247,9 +247,43 @@ export interface MutationOptions<
   TVariables = void,
   TContext = unknown
 > extends MutateOptions<TData, TError, TVariables, TContext> {
+  mutationFn?: MutationFunction<TData, TVariables>
   onMutate?: (variables: TVariables) => Promise<TContext> | TContext
   useErrorBoundary?: boolean
   suspense?: boolean
+}
+
+export type MutateFunction<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+> = (
+  variables: TVariables,
+  options?: MutateOptions<TData, TError, TVariables, TContext>
+) => Promise<TData>
+
+export type MutationFunction<TData = unknown, TVariables = void> = (
+  variables: TVariables
+) => TData | Promise<TData>
+
+export type MutationStatus = 'idle' | 'loading' | 'error' | 'success'
+
+export interface MutationObserverResult<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown
+> {
+  data: TData | undefined
+  error: TError | null
+  isError: boolean
+  isIdle: boolean
+  isLoading: boolean
+  isSuccess: boolean
+  mutate: MutateFunction<TData, TError, TVariables, TContext>
+  reset: () => void
+  status: MutationStatus
 }
 
 export interface DefaultOptions<TError = unknown> {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,7 @@
 import type { Query } from './query'
 import type {
+  MutationFunction,
+  MutationOptions,
   QueryFunction,
   QueryKey,
   QueryKeyHashFunction,
@@ -125,6 +127,14 @@ export function replaceAt<T>(array: T[], index: number, value: T): T[] {
 
 export function timeUntilStale(updatedAt: number, staleTime?: number): number {
   return Math.max(updatedAt + (staleTime || 0) - Date.now(), 0)
+}
+
+export function parseMutationArgs<
+  TOptions extends MutationOptions<any, any, any, any>
+>(arg1: MutationFunction<any, any> | TOptions, arg2?: TOptions): TOptions {
+  return (typeof arg1 === 'function'
+    ? { ...arg2, mutationFn: arg1 }
+    : arg1) as TOptions
 }
 
 export function parseQueryArgs<TOptions extends QueryOptions<any, any>>(
@@ -359,6 +369,10 @@ export function isError(value: any): value is Error {
 
 export function isCancelledError(value: any): value is CancelledError {
   return value instanceof CancelledError
+}
+
+export function isDefined<T>(value: T | undefined): value is T {
+  return typeof value !== 'undefined'
 }
 
 export function sleep(timeout: number): Promise<void> {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,6 +1,7 @@
 import {
   MutateOptions,
   MutationOptions,
+  MutationStatus,
   QueryObserverOptions,
   QueryObserverResult,
 } from '../core/types'
@@ -33,26 +34,20 @@ export interface UseQueryResult<TData = unknown, TError = unknown>
 export interface UseInfiniteQueryResult<TData = unknown, TError = unknown>
   extends UseBaseQueryResult<TData[], TError> {}
 
-export type MutationStatus = 'idle' | 'loading' | 'error' | 'success'
-
-export type MutationFunction<TData = unknown, TVariables = unknown> = (
-  variables: TVariables
-) => Promise<TData>
-
-export type MutateFunction<
+export type UseMutateFunction<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown
 > = (
   variables: TVariables,
   options?: MutateOptions<TData, TError, TVariables, TContext>
 ) => void
 
-export type MutateAsyncFunction<
+export type UseMutateAsyncFunction<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown
 > = (
   variables: TVariables,
@@ -65,7 +60,7 @@ export interface UseMutationOptions<TData, TError, TVariables, TContext>
 export interface UseMutationResult<
   TData = unknown,
   TError = unknown,
-  TVariables = unknown,
+  TVariables = void,
   TContext = unknown
 > {
   data: TData | undefined
@@ -74,8 +69,8 @@ export interface UseMutationResult<
   isIdle: boolean
   isLoading: boolean
   isSuccess: boolean
-  mutate: MutateFunction<TData, TError, TVariables, TContext>
-  mutateAsync: MutateAsyncFunction<TData, TError, TVariables, TContext>
+  mutate: UseMutateFunction<TData, TError, TVariables, TContext>
+  mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext>
   reset: () => void
   status: MutationStatus
 }

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -1,96 +1,17 @@
 import React from 'react'
 
 import { useIsMounted } from './utils'
-import { getStatusProps, noop } from '../core/utils'
-import { getLogger } from '../core/logger'
-import { notifyManager } from '../core/notifyManager'
+import { noop, parseMutationArgs } from '../core/utils'
+import { MutationObserver } from '../core/mutationObserver'
 import { useQueryClient } from './QueryClientProvider'
 import {
-  MutateAsyncFunction,
-  MutateFunction,
-  MutationFunction,
-  MutationStatus,
+  UseMutateFunction,
   UseMutationOptions,
   UseMutationResult,
 } from './types'
-
-// TYPES
-
-type Reducer<S, A> = (prevState: S, action: A) => S
-
-interface State<TData, TError> {
-  status: MutationStatus
-  data: TData | undefined
-  error: TError | null
-  isIdle: boolean
-  isLoading: boolean
-  isSuccess: boolean
-  isError: boolean
-}
-
-interface ResetAction {
-  type: 'reset'
-}
-
-interface LoadingAction {
-  type: 'loading'
-}
-
-interface SuccessAction<TData> {
-  type: 'success'
-  data: TData
-}
-
-interface ErrorAction<TError> {
-  type: 'error'
-  error: TError
-}
-
-type Action<TData, TError> =
-  | ErrorAction<TError>
-  | LoadingAction
-  | ResetAction
-  | SuccessAction<TData>
+import { MutationFunction } from '../core/types'
 
 // HOOK
-
-function getDefaultState<TData, TError>(): State<TData, TError> {
-  return {
-    ...getStatusProps('idle'),
-    data: undefined,
-    error: null,
-  }
-}
-
-function reducer<TData, TError>(
-  state: State<TData, TError>,
-  action: Action<TData, TError>
-): State<TData, TError> {
-  switch (action.type) {
-    case 'reset':
-      return getDefaultState()
-    case 'loading':
-      return {
-        ...getStatusProps('loading'),
-        data: undefined,
-        error: null,
-      }
-    case 'success':
-      return {
-        ...getStatusProps('success'),
-        data: action.data,
-        error: null,
-      }
-    case 'error':
-      return {
-        ...getStatusProps('error'),
-        data: undefined,
-        error: action.error,
-      }
-    default:
-      return state
-  }
-}
 
 export function useMutation<
   TData = unknown,
@@ -101,101 +22,53 @@ export function useMutation<
   mutationFn: MutationFunction<TData, TVariables>,
   options: UseMutationOptions<TData, TError, TVariables, TContext> = {}
 ): UseMutationResult<TData, TError, TVariables, TContext> {
+  const parsedOptions = parseMutationArgs(mutationFn, options)
   const isMounted = useIsMounted()
-  const [state, dispatch] = React.useReducer(
-    reducer as Reducer<State<TData, TError>, Action<TData, TError>>,
-    null,
-    getDefaultState
-  )
-
-  const safeDispatch = React.useCallback<typeof dispatch>(
-    action => {
-      notifyManager.schedule(() => {
-        if (isMounted()) {
-          dispatch(action)
-        }
-      })
-    },
-    [dispatch, isMounted]
-  )
-
   const client = useQueryClient()
-  const defaultedOptions = client.defaultMutationOptions(options)
-  const lastMutationIdRef = React.useRef(0)
-  const lastMutationFnRef = React.useRef(mutationFn)
-  lastMutationFnRef.current = mutationFn
-  const lastOptionsRef = React.useRef(defaultedOptions)
-  lastOptionsRef.current = defaultedOptions
 
-  const mutateAsync = React.useCallback<
-    MutateAsyncFunction<TData, TError, TVariables, TContext>
-  >(
-    (vars, mutateOpts = {}): Promise<TData> => {
-      const mutationId = ++lastMutationIdRef.current
-      const mutationOpts = lastOptionsRef.current
-      const lastMutationFn = lastMutationFnRef.current
+  // Create mutation observer
+  const observerRef = React.useRef<
+    MutationObserver<TData, TError, TVariables, TContext>
+  >()
+  const firstRender = !observerRef.current
+  const observer = observerRef.current || client.watchMutation(parsedOptions)
+  observerRef.current = observer
 
-      let ctx: TContext | undefined
-      let data: TData
+  // Update options
+  if (!firstRender) {
+    observer.setOptions(parsedOptions)
+  }
 
-      safeDispatch({ type: 'loading' })
+  const [currentResult, setCurrentResult] = React.useState(() =>
+    observer.getCurrentResult()
+  )
 
-      return Promise.resolve()
-        .then(() => mutationOpts.onMutate?.(vars))
-        .then(context => {
-          ctx = context
-        })
-        .then(() => lastMutationFn(vars))
-        .then(result => {
-          data = result
-        })
-        .then(() => mutationOpts.onSuccess?.(data, vars, ctx))
-        .then(() => mutationOpts.onSettled?.(data, null, vars, ctx))
-        .then(() => mutateOpts.onSuccess?.(data, vars, ctx))
-        .then(() => mutateOpts.onSettled?.(data, null, vars, ctx))
-        .then(() => {
-          if (lastMutationIdRef.current === mutationId) {
-            safeDispatch({ type: 'success', data })
-          }
-          return data
-        })
-        .catch(error => {
-          getLogger().error(error)
-          return Promise.resolve()
-            .then(() => mutationOpts.onError?.(error, vars, ctx))
-            .then(() => mutationOpts.onSettled?.(undefined, error, vars, ctx))
-            .then(() => mutateOpts.onError?.(error, vars, ctx))
-            .then(() => mutateOpts.onSettled?.(undefined, error, vars, ctx))
-            .then(() => {
-              if (lastMutationIdRef.current === mutationId) {
-                safeDispatch({ type: 'error', error })
-              }
-              throw error
-            })
-        })
-    },
-    [safeDispatch]
+  // Subscribe to the observer
+  React.useEffect(
+    () =>
+      observer.subscribe(result => {
+        if (isMounted()) {
+          setCurrentResult(result)
+        }
+      }),
+    [observer, isMounted]
   )
 
   const mutate = React.useCallback<
-    MutateFunction<TData, TError, TVariables, TContext>
+    UseMutateFunction<TData, TError, TVariables, TContext>
   >(
     (variables, mutateOptions) => {
-      mutateAsync(variables, mutateOptions).catch(noop)
+      observer.mutate(variables, mutateOptions).catch(noop)
     },
-    [mutateAsync]
+    [observer]
   )
 
-  const reset = React.useCallback(() => {
-    safeDispatch({ type: 'reset' })
-  }, [safeDispatch])
+  if (
+    currentResult.error &&
+    (observer.options.useErrorBoundary || observer.options.suspense)
+  ) {
+    throw currentResult.error
+  }
 
-  React.useEffect(() => {
-    const lastOptions = lastOptionsRef.current
-    if (state.error && (lastOptions.useErrorBoundary || lastOptions.suspense)) {
-      throw state.error
-    }
-  }, [state.error])
-
-  return { ...state, mutate, mutateAsync, reset }
+  return { ...currentResult, mutate, mutateAsync: currentResult.mutate }
 }


### PR DESCRIPTION
PR to explore support for plugins/middleware. The implementation supports chaining and short circuiting for queries and mutations. Some initial questions:
1. How useful would this be?
2. To also support mutations they had to be moved into the core. Which might be a good thing because the mutation logic can then be re-used in different frameworks. But on the other hand, are mutations really a concept?
3. If mutations are actually a thing, do we then also want to show them in the devtools? And if so, how would they be identified?