### PR TITLE
Easier Contributions.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+tasks:
+  - name: Auto Build
+    init: |
+      yarn install
+      gp sync-done boot
+    command: yarn run start
+
+  - name: Docs
+    before: cd docs/
+    init: |
+      gp sync-await boot
+      yarn install
+    command: yarn dev
+    openMode: split-right
+
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,17 @@ If you have been assigned to fix an issue or develop a new feature, please follo
 - Git stage your required changes and commit (see below commit guidelines)
 - Submit PR for review
 
+## Online one-click setup
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for developing online. With a single click it will start a workspace and automatically:
+
+- clone the `react-query` repo.
+- install all the dependencies in `/` and `/docs`.
+- run `yarn start` in the root(`/`) to Auto-build files.
+- run `yarn dev` in `/docs`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Commit message conventions
 
 `react-query` is using [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Hooks for fetching, caching and updating asynchronous data in React
   <img alt="" src="https://img.shields.io/github/stars/tannerlinsley/react-query.svg?style=social&label=Star" />
 </a><a href="https://twitter.com/tannerlinsley" target="\_parent">
   <img alt="" src="https://img.shields.io/twitter/follow/tannerlinsley.svg?style=social&label=Follow" />
+</a> <a href="https://gitpod.io/from-referrer/">
+  <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"/>
 </a>
 
 Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [React Table](https://github.com/tannerlinsley/react-table), [React Form](https://github.com/tannerlinsley/react-form), [React Charts](https://github.com/tannerlinsley/react-charts)


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `react-query` repo.
- install all the dependencies in `/` and `/docs`.
- run `yarn start` in the root(`/`) to Auto-build files.
- run `yarn dev` in `/docs`.

This way anyone interested in contributing can start straight away without any friction.

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95647609-1708a680-0aea-11eb-829e-6f63a1bfcdb0.png)

You can give it a try on my fork of the repo via the following link:
 
https://github.com/nisarhassan12/react-query

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

Please let me know if there is anything that can be improved. I would to help.