### PR TITLE
docs(api): change manual to isEnabled

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -157,7 +157,7 @@ const queryInfo = useQuery({
     - `idle` if the query is idle. This only happens if a query is initialized with `enabled: false` and no initial data is available.
     - `loading` if the query is in a "hard" loading state. This means there is no cached data and the query is currently fetching, eg `isFetching === true`
     - `error` if the query attempt resulted in an error. The corresponding `error` property has the error received from the attempted fetch
-    - `success` if the query has received a response with no errors and is ready to display its data. The corresponding `data` property on the query is the data received from the successful fetch or if the query is in `manual` mode and has not been fetched yet `data` is the first `initialData` supplied to the query on initialization.
+    - `success` if the query has received a response with no errors and is ready to display its data. The corresponding `data` property on the query is the data received from the successful fetch or if the query's `enabled` property is set to `false` and has not been fetched yet `data` is the first `initialData` supplied to the query on initialization.
 - `isIdle: Boolean`
   - A derived boolean from the `status` variable above, provided for convenience.
 - `isLoading: Boolean`
@@ -180,7 +180,7 @@ const queryInfo = useQuery({
   - Will be `true` if the query has been fetched after the component mounted.
   - This property can be used to not show any previously cached data.
 - `isFetching: Boolean`
-  - Defaults to `true` so long as `manual` is set to `false`
+  - Defaults to `true` so long as `enabled` is set to `false`
   - Will be `true` if the query is currently fetching, including background fetching.
 - `failureCount: Integer`
   - The failure count for the query.


### PR DESCRIPTION
## Description

From my understand, the `manual` property was changed to `enabled`. This pull request updates the documentation to reflect that change.