### PR TITLE
fix: add descriptive error when missing queryFn

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -54,7 +54,7 @@ export const DEFAULT_CONFIG: ReactQueryConfig = {
     cacheTime: 5 * 60 * 1000,
     enabled: true,
     notifyOnStatusChange: true,
-    queryFn: () => Promise.reject(),
+    queryFn: () => Promise.reject(new Error('react-query: missing queryFn')),
     queryKeySerializerFn: defaultQueryKeySerializerFn,
     refetchOnMount: true,
     refetchOnReconnect: true,


### PR DESCRIPTION
The empty `Promise.reject()` call in `config.ts` causes meaningless errors to appear in our bug tracker that look like this:
![image](https://user-images.githubusercontent.com/189950/96037944-16467c00-0e2c-11eb-893d-2aa46cf4b1ab.png)

I'm pretty sure we are hitting this error due to [this issue](https://github.com/tannerlinsley/react-query/issues/1088) in react-query v2 (fixed in v3). It took quite a while to figure out what was causing those bug reports though. A meaningful error message could save hours and hours of debugging.