### PR TITLE
feat: add data, error and fetch origins

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -198,7 +198,9 @@ export class QueryClient {
     const [filters, options] = parseFilterArgs(arg1, arg2, arg3)
 
     const promises = notifyManager.batch(() =>
-      this.queryCache.findAll(filters).map(query => query.fetch())
+      this.queryCache
+        .findAll(filters)
+        .map(query => query.fetch(undefined, { origin: 'clientRefetch' }))
     )
 
     let promise = Promise.all(promises).then(noop)
@@ -240,7 +242,7 @@ export class QueryClient {
     const query = this.queryCache.build(this, defaultedOptions)
 
     return query.isStaleByTime(defaultedOptions.staleTime)
-      ? query.fetch(defaultedOptions)
+      ? query.fetch(defaultedOptions, { origin: 'clientFetch' })
       : Promise.resolve(query.state.data as TData)
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,10 @@
 import type { MutationState } from './mutation'
-import type { QueryBehavior } from './query'
+import type {
+  QueryBehavior,
+  QueryDataOrigin,
+  QueryErrorOrigin,
+  QueryFetchOrigin,
+} from './query'
 import type { RetryValue, RetryDelayValue } from './retryer'
 import type { QueryFilters } from './utils'
 
@@ -190,7 +195,9 @@ export interface ResultOptions {
   throwOnError?: boolean
 }
 
-export interface RefetchOptions extends ResultOptions {}
+export interface RefetchOptions extends ResultOptions {
+  origin?: QueryFetchOrigin
+}
 
 export interface InvalidateQueryFilters extends QueryFilters {
   refetchActive?: boolean
@@ -213,8 +220,11 @@ export type QueryStatus = 'idle' | 'loading' | 'error' | 'success'
 
 export interface QueryObserverResult<TData = unknown, TError = unknown> {
   data: TData | undefined
+  dataOrigin?: QueryDataOrigin
   error: TError | null
+  errorOrigin?: QueryErrorOrigin
   failureCount: number
+  fetchOrigin?: QueryFetchOrigin
   isError: boolean
   isFetched: boolean
   isFetchedAfterMount: boolean

--- a/src/react/tests/useInfiniteQuery.test.tsx
+++ b/src/react/tests/useInfiniteQuery.test.tsx
@@ -73,8 +73,11 @@ describe('useInfiniteQuery', () => {
     expect(states.length).toBe(2)
     expect(states[0]).toEqual({
       data: undefined,
+      dataOrigin: undefined,
       error: null,
+      errorOrigin: undefined,
       failureCount: 0,
+      fetchOrigin: 'observerFetch',
       fetchNextPage: expect.any(Function),
       fetchPreviousPage: expect.any(Function),
       hasNextPage: undefined,
@@ -99,7 +102,9 @@ describe('useInfiniteQuery', () => {
 
     expect(states[1]).toEqual({
       data: { pages: [0], pageParams: [undefined] },
+      dataOrigin: 'observerFetch',
       error: null,
+      errorOrigin: undefined,
       failureCount: 0,
       fetchNextPage: expect.any(Function),
       fetchPreviousPage: expect.any(Function),

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -133,8 +133,11 @@ describe('useQuery', () => {
 
     expect(states[0]).toEqual({
       data: undefined,
+      dataOrigin: undefined,
       error: null,
+      errorOrigin: undefined,
       failureCount: 0,
+      fetchOrigin: 'observerFetch',
       isError: false,
       isFetched: false,
       isFetchedAfterMount: false,
@@ -153,8 +156,11 @@ describe('useQuery', () => {
 
     expect(states[1]).toEqual({
       data: 'test',
+      dataOrigin: 'observerFetch',
       error: null,
+      errorOrigin: undefined,
       failureCount: 0,
+      fetchOrigin: undefined,
       isError: false,
       isFetched: true,
       isFetchedAfterMount: true,
@@ -203,8 +209,11 @@ describe('useQuery', () => {
 
     expect(states[0]).toEqual({
       data: undefined,
+      dataOrigin: undefined,
       error: null,
+      errorOrigin: undefined,
       failureCount: 0,
+      fetchOrigin: 'observerFetch',
       isError: false,
       isFetched: false,
       isFetchedAfterMount: false,
@@ -223,8 +232,11 @@ describe('useQuery', () => {
 
     expect(states[1]).toEqual({
       data: undefined,
+      dataOrigin: undefined,
       error: null,
+      errorOrigin: undefined,
       failureCount: 1,
+      fetchOrigin: 'observerFetch',
       isError: false,
       isFetched: false,
       isFetchedAfterMount: false,
@@ -243,8 +255,11 @@ describe('useQuery', () => {
 
     expect(states[2]).toEqual({
       data: undefined,
+      dataOrigin: undefined,
       error: 'rejected',
+      errorOrigin: 'observerFetch',
       failureCount: 2,
+      fetchOrigin: undefined,
       isError: true,
       isFetched: false,
       isFetchedAfterMount: false,
@@ -701,15 +716,17 @@ describe('useQuery', () => {
 
     await sleep(20)
 
-    expect(states.length).toBe(4)
+    expect(states.length).toBe(5)
     // Initial
     expect(states[0]).toMatchObject({ data: undefined, updatedAt: 0 })
     // Fetched
     expect(states[1]).toMatchObject({ data: 1 })
     // Switch
     expect(states[2]).toMatchObject({ data: undefined, updatedAt: 0 })
+    // Switch
+    expect(states[3]).toMatchObject({ data: undefined, updatedAt: 0 })
     // Fetched
-    expect(states[3]).toMatchObject({ data: 2 })
+    expect(states[4]).toMatchObject({ data: 2 })
   })
 
   it('should share equal data structures between query results', async () => {


### PR DESCRIPTION
This PR adds some properties to the query to indicate where a fetch, data or error originated from.

This could be useful for:
- Knowing if the data in the cache came from the server or from some local update.
- Not showing loading indicators when refetching because of a window focus for example.
- Not showing errors if they originated from a window focus for example.
- Debugging

It's an idea, would love to to get some feedback on it.