### PR TITLE
feat: pass queryKey to select function

### DIFF
--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -127,7 +127,7 @@ const result = useQuery({
 - `onSettled: (data?: TData, error?: TError) => void`
   - Optional
   - This function will fire any time the query is either successfully fetched or errors and be passed either the data or error
-- `select: (data: TData) => unknown`
+- `select: (data: TData, queryKey: unknown[]) => unknown`
   - Optional
   - This option can be used to transform or select a part of the data returned by the query function.
 - `suspense: boolean`

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -362,7 +362,7 @@ export class QueryObserver<
       if (this.currentResult && state.data === this.currentResultState?.data) {
         data = this.currentResult.data
       } else {
-        data = this.options.select(state.data)
+        data = this.options.select(state.data, this.options.queryKey)
         if (this.options.structuralSharing !== false) {
           data = replaceEqualDeep(this.currentResult?.data, data)
         }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -149,7 +149,7 @@ export interface QueryObserverOptions<
   /**
    * This option can be used to transform or select a part of the data returned by the query function.
    */
-  select?: (data: TQueryData) => TData
+  select?: (data: TQueryData, queryKey?: QueryKey) => TData
   /**
    * If set to `true`, the query will suspend when `status === 'loading'`
    * and throw errors when `status === 'error'`.


### PR DESCRIPTION
I've been playing around with the v3 beta over the last week and have really been enjoying it!

One API that that seems exciting to me is `queryClient.setQueryDefaults`. I've been exploring different use cases for it and discovered 2 issues https://github.com/tannerlinsley/react-query/issues/1214 and https://github.com/tannerlinsley/react-query/issues/1219 (both fixed super fast by @boschni _thanks!_ 😄 )

I've now came across another use case which while not yet supported, I don't think can be considered an issue.
The use case I'm exploring is setting a default `select` function in `queryClient.setQueryDefaults`. 
As I see it `select` allows for "over fetching" data and then selecting the parts needed in that specific view.
What I'm exploring is a case where one may always wanted to fetch an entire list (assuming the list is small) and then `select` the individual records in the view.

I was able to get 95% of the way there, the only part that is missing is having access to the `queryKey` in the  `select function.

Having access to the `queryKey` in select would allow having a default select method set in `queryClient.setQueryDefaults`, giving the ability to "select" data from the full list just by doing something like `useQuery(['list', id])`  

It's probably easier to see what I mean by looking at an example so I created a created a sandbox thats running with my patch to demonstrate
https://codesandbox.io/s/infallible-shadow-vtzmt?file=/src/index.js:575-603

In the sandbox any call to either `useQuery(['todos'])` or `useQuery(['todos', id])` will trigger a fetch of all the todos. By setting the `queryHash` we can ensure that there will only be a single copy of the `todos` in  the cache. 

Thanks again for a great library, I'd love to hear what you have to say about this use case...