### PR TITLE
Update React peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/runtime": "^7.5.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "react-dom": {


### PR DESCRIPTION
Update React peer dependency to include v17. Without this change everything is working fine but "incorrect peer dependency" warning appears in the console.

I think no CI change is necessary to run tests over React v16 and v17?