### PR TITLE
docs(infiniteQuery guide): include missing error

### DIFF
--- a/docs/src/pages/docs/guides/infinite-queries.md
+++ b/docs/src/pages/docs/guides/infinite-queries.md
@@ -50,6 +50,7 @@ function Projects() {
     isFetchingMore,
     fetchMore,
     canFetchMore,
+    error,
   } = useInfiniteQuery('projects', fetchProjects, {
     getFetchMore: (lastGroup, allGroups) => lastGroup.nextCursor,
   })


### PR DESCRIPTION
In the example, the error on line 60 - `error.message` - is undefined. This adds the error to the destructured return value of useInfiniteQuery.

Thanks for an awesome lib and fantastic docs!