### PR TITLE
docs: fix typo for options used in querycache

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -382,7 +382,7 @@ Its available properties and methods are:
 
 **Options**
 
-- `defaultConfig: QueryQueryConfig`
+- `defaultConfig: QueryConfig`
   - Optional
   - Define defaults for all queries and mutations using this query cache.
 


### PR DESCRIPTION
Fixing typo for the type of `defaultConfig`