### PR TITLE
feat(useQuery): Add refetchNever config option to always use cache wh…

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -57,6 +57,7 @@ export const DEFAULT_CONFIG: ReactQueryConfig = {
     queryFn: () => Promise.reject(),
     queryKeySerializerFn: defaultQueryKeySerializerFn,
     refetchOnMount: true,
+    refetchNever: false,
     refetchOnReconnect: true,
     refetchOnWindowFocus: true,
     retry: 3,

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -172,6 +172,7 @@ export class QueryObserver<TResult, TError> {
     if (
       this.config.enabled && // Only fetch if enabled
       this.isStale && // Only fetch if stale
+      !(this.config.refetchNever && this.currentResult.isFetched) && // If refetchNever is `true` and we have the data in the cache then don't refetch
       !(this.config.suspense && this.currentResult.isFetched) && // Don't refetch if in suspense mode and the data is already fetched
       (this.config.refetchOnMount || this.currentQuery.observers.length === 1)
     ) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -117,14 +117,14 @@ export interface QueryObserverConfig<
    * Defaults to `true`.
    */
   refetchOnMount?: boolean | 'always'
-  /**
-   * Set this to `true` to always fetch when the component mounts (regardless of staleness).
-   * Defaults to `false`.
+   /**
+   * Set this to `true` to never fetch data if there is a cache for it, even if no components were previosuley mounted.
+   * Defaults to `false`
    */
   refetchNever?: boolean
   /**
-   * Set this to `true` ro never fetch data if there is a cache for it, even if no components were previosuley mounted.
-   * Defaults to `false`
+   * Set this to `true` to always fetch when the component mounts (regardless of staleness).
+   * Defaults to `false`.
    */
   forceFetchOnMount?: boolean
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -121,6 +121,11 @@ export interface QueryObserverConfig<
    * Set this to `true` to always fetch when the component mounts (regardless of staleness).
    * Defaults to `false`.
    */
+  refetchNever?: boolean
+  /**
+   * Set this to `true` ro never fetch data if there is a cache for it, even if no components were previosuley mounted.
+   * Defaults to `false`
+   */
   forceFetchOnMount?: boolean
   /**
    * Whether a change to the query status should re-render a component.


### PR DESCRIPTION
This features allows a config option to always use cache to serve data and never hit the API if a cache exists for the given query key.  This is useful when, for example, loading static files with react-query as there is no point in revalidating the cache as it will never change. `refetchOnMount` is not always sufficient as sometimes user activity may unmount a component and when it is remounted the developer may want to avoid revalidating the cache. If the file is several megabytes and we know the cache is good, why bother revalidating it?

I have a use case where I load static json files (so they never change) they have WebGL vertex plots in them and they can get big (several megs) I tried `refetchOnMount` but sometimes the component with the useQuery Hook unmount. I could have an invisible copy of a component with the hook always in the DOM but that is a bit of a hack so I thought this feature may be useful.

**tl;dr this option prevents cache revalidation in all circumstances.**

Looking forward to your feedback.

I'm hoping this feature can merge go in as I don't want to maintain this fork forever 🤣 . Go easy on me I'm fairly new to Open Source. Thanks for the great Lib.