### PR TITLE
fix: clearTimeout instead of clearInterval

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -233,7 +233,7 @@ export class QueryObserver<TResult, TError> {
 
   private clearStaleTimeout(): void {
     if (this.staleTimeoutId) {
-      clearInterval(this.staleTimeoutId)
+      clearTimeout(this.staleTimeoutId)
       this.staleTimeoutId = undefined
     }
   }


### PR DESCRIPTION
Jest's modern timers break because the stale timeout is created with `setTimeout` but cleared with `clearInterval`. This stops them from breaking because we are now clearing the timer with `clearTimeout`.

### Stacktrace
```
 Error: Uncaught [Error: Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()]
        at reportException (node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:62:24)
        at innerInvokeEventListeners (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:333:9)
        at invokeEventListeners (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
        at HTMLUnknownElementImpl._dispatch (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:221:9)
        at HTMLUnknownElementImpl.dispatchEvent (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:94:17)
        at HTMLUnknownElement.dispatchEvent (/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:231:34)
        at Object.invokeGuardedCallbackDev (/node_modules/react-dom/cjs/react-dom.development.js:3994:16)
        at invokeGuardedCallback (/node_modules/react-dom/cjs/react-dom.development.js:4056:31)
        at flushPassiveEffectsImpl /node_modules/react-dom/cjs/react-dom.development.js:23543:11)
        at unstable_runWithPriority /node_modules/scheduler/cjs/scheduler.development.js:646:12) Error: Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()
        at clearTimer (/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:458:23)
        at Object.clearInterval (/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:790:20)
        at target.<computed> /node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:567:38)
        at QueryObserver.clearStaleTimeout (/node_modules/react-query/lib/core/queryObserver.js:197:7)
        at QueryObserver.clearTimers (/node_modules/react-query/lib/core/queryObserver.js:191:10)
        at QueryObserver.unsubscribe (/node_modules/react-query/lib/core/queryObserver.js:50:10)
        at HTMLUnknownElement.callCallback (/node_modules/react-dom/cjs/react-dom.development.js:3945:14)
        at HTMLUnknownElement.callTheUserObjectsOperation /node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
        at innerInvokeEventListeners (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:318:25)
        at invokeEventListeners (/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
```