### PR TITLE
feat: Add snapshotValue to use mutation success paths

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -233,7 +233,7 @@ export interface MutateConfig<
   TVariables = unknown,
   TSnapshot = unknown
 > {
-  onSuccess?: (data: TResult, variables: TVariables) => Promise<unknown> | void
+  onSuccess?: (data: TResult, variables: TVariables, snapshotValue: TSnapshot) => Promise<unknown> | void
   onError?: (
     error: TError,
     variables: TVariables,
@@ -243,7 +243,7 @@ export interface MutateConfig<
     data: undefined | TResult,
     error: TError | null,
     variables: TVariables,
-    snapshotValue?: TSnapshot
+    snapshotValue: TSnapshot
   ) => Promise<unknown> | void
   throwOnError?: boolean
 }

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -152,10 +152,10 @@ export function useMutation<
           dispatch({ type: ActionType.Resolve, data })
         }
 
-        await latestConfig.onSuccess?.(data, variables!)
-        await mutateConfig.onSuccess?.(data, variables!)
-        await latestConfig.onSettled?.(data, null, variables!)
-        await mutateConfig.onSettled?.(data, null, variables!)
+        await latestConfig.onSuccess?.(data, variables!, snapshotValue)
+        await mutateConfig.onSuccess?.(data, variables!, snapshotValue)
+        await latestConfig.onSettled?.(data, null, variables!, snapshotValue)
+        await mutateConfig.onSettled?.(data, null, variables!, snapshotValue)
 
         return data
       } catch (error) {
@@ -172,7 +172,7 @@ export function useMutation<
           undefined,
           error,
           variables!,
-          snapshotValue
+          snapshotValue as TSnapshot
         )
 
         if (isLatest()) {


### PR DESCRIPTION
I raised a discussion a while back, my scenario is around optimistic concurrency and being able to remove the _in progress_ items on success.

https://github.com/tannerlinsley/react-query/discussions/1063

I have chosen to add the pending items outside react query's query cache, meaning invalidating the cache will not help me. Without having access to the snapshot value there is no way to pass state between the use mutation action and the success methods.