### PR TITLE
Throw error when QueryClientProvider has not been used to set a query client

### DIFF
--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -22,6 +22,8 @@ This has some benefits:
 
 Use the `QueryClientProvider` component to connect a `QueryClient` to your application:
 
+**NOTE** There is no longer a default query cache, you must connect your application to a query provider manually
+
 ```js
 import { QueryClient, QueryClientProvider } from 'react-query'
 

--- a/src/react/QueryClientProvider.tsx
+++ b/src/react/QueryClientProvider.tsx
@@ -6,7 +6,13 @@ const QueryClientContext = React.createContext<QueryClient | undefined>(
   undefined
 )
 
-export const useQueryClient = () => React.useContext(QueryClientContext)!
+export const useQueryClient = () => {
+  const queryClient = React.useContext(QueryClientContext)
+  if (!queryClient) {
+    throw new Error('No QueryClient set, use QueryClientProvider to set one')
+  }
+  return queryClient
+}
 
 export interface QueryClientProviderProps {
   client: QueryClient


### PR DESCRIPTION
After migrating to v3, I had a number of tests fail because I was not using an explicit queryCache before the migration. Another option is to create a default query client, but I prefer having to do this step yourself personally. 

The error I got was `Error: Uncaught [TypeError: Cannot read property 'defaultMutationOptions' of undefined]`

Added a error message so this is now the error my tests give:

<img width="553" alt="image" src="https://user-images.githubusercontent.com/453152/99872082-2bc47800-2c1a-11eb-82db-9530f8816dfb.png">


