### PR TITLE
fixed(queryObserver): fetch data twice when mounted

### DIFF
--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -67,8 +67,7 @@ export function useBaseQuery<TResult, TError>(
       !result.isSuccess
     ) {
       errorResetBoundary.clearReset()
-      const unsubscribe = observer.subscribe()
-      throw observer.fetch().finally(unsubscribe)
+      throw observer.fetch().finally(observer.unsubscribe)
     }
   }
 


### PR DESCRIPTION
### Fixed

* Only work once when forceFetchOnMount is ture or refetchOnMount is 'always'