### PR TITLE
fixed(queryObserver): fetch data twice when mounted 

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -197,14 +197,12 @@ export class Query<TResult, TError> {
     // Get the new data
     let data: TResult | undefined = functionalUpdate(updater, prevData)
 
-    // Structurally share data between prev and new data if needed
-    if (this.config.structuralSharing) {
-      data = replaceEqualDeep(prevData, data)
-    }
-
     // Use prev data if an isDataEqual function is defined and returns `true`
     if (this.config.isDataEqual?.(prevData, data)) {
       data = prevData
+    } else if (this.config.structuralSharing) {
+      // Structurally share data between prev and new data if needed
+      data = replaceEqualDeep(prevData, data)
     }
 
     // Try to determine if more data can be fetched

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -64,10 +64,12 @@ export function useBaseQuery<TResult, TError>(
     if (
       resolvedConfig.enabled &&
       resolvedConfig.suspense &&
-      !result.isSuccess
+      !result.isSuccess &&
+      !result.isFetching
     ) {
       errorResetBoundary.clearReset()
-      throw observer.fetch().finally(observer.unsubscribe)
+      const unsubscribe = observer.subscribe()
+      throw observer.fetch().finally(unsubscribe)
     }
   }
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -67,8 +67,7 @@ export function useBaseQuery<TResult, TError>(
       !result.isSuccess
     ) {
       errorResetBoundary.clearReset()
-      const unsubscribe = observer.subscribe()
-      throw observer.fetch().finally(unsubscribe)
+      throw observer.fetch().finally(observer.unsubscribe)
     }
   }
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -64,8 +64,7 @@ export function useBaseQuery<TResult, TError>(
     if (
       resolvedConfig.enabled &&
       resolvedConfig.suspense &&
-      !result.isSuccess &&
-      !result.isFetching
+      !result.isSuccess
     ) {
       errorResetBoundary.clearReset()
       const unsubscribe = observer.subscribe()


### PR DESCRIPTION
Fixed
Only work once when forceFetchOnMount is ture or refetchOnMount is 'always'