### PR TITLE
fix(types): change the order of types so that correct type inference is picked for **Object syntax**

### DIFF
--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -19,6 +19,11 @@ export interface UseInfiniteQueryObjectConfig<TResult, TError> {
 
 // HOOK
 
+// Object syntax
+export function useInfiniteQuery<TResult = unknown, TError = unknown>(
+  config: UseInfiniteQueryObjectConfig<TResult, TError>
+): InfiniteQueryResult<TResult, TError>
+  
 // Parameter syntax with optional config
 export function useInfiniteQuery<TResult = unknown, TError = unknown>(
   queryKey: QueryKey,
@@ -40,11 +45,6 @@ export function useInfiniteQuery<TResult = unknown, TError = unknown>(
   queryKey: QueryKey,
   queryFn: QueryFunction<TResult>,
   queryConfig?: InfiniteQueryConfig<TResult, TError>
-): InfiniteQueryResult<TResult, TError>
-
-// Object syntax
-export function useInfiniteQuery<TResult = unknown, TError = unknown>(
-  config: UseInfiniteQueryObjectConfig<TResult, TError>
 ): InfiniteQueryResult<TResult, TError>
 
 // Implementation

--- a/src/react/usePaginatedQuery.ts
+++ b/src/react/usePaginatedQuery.ts
@@ -24,6 +24,11 @@ export interface UsePaginatedQueryObjectConfig<TResult, TError> {
 
 // HOOK
 
+// Object syntax
+export function usePaginatedQuery<TResult = unknown, TError = unknown>(
+  config: UsePaginatedQueryObjectConfig<TResult, TError>
+): PaginatedQueryResult<TResult, TError>
+
 // Parameter syntax with optional config
 export function usePaginatedQuery<TResult = unknown, TError = unknown>(
   queryKey: QueryKey,
@@ -45,11 +50,6 @@ export function usePaginatedQuery<TResult = unknown, TError = unknown>(
   queryKey: QueryKey,
   queryFn: QueryFunction<TResult>,
   queryConfig?: PaginatedQueryConfig<TResult, TError>
-): PaginatedQueryResult<TResult, TError>
-
-// Object syntax
-export function usePaginatedQuery<TResult = unknown, TError = unknown>(
-  config: UsePaginatedQueryObjectConfig<TResult, TError>
 ): PaginatedQueryResult<TResult, TError>
 
 // Implementation

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -19,6 +19,11 @@ export interface UseQueryObjectConfig<TResult, TError> {
 
 // HOOK
 
+// Object syntax
+export function useQuery<TResult = unknown, TError = unknown>(
+  config: UseQueryObjectConfig<TResult, TError>
+): QueryResult<TResult, TError>
+  
 // Parameter syntax with optional config
 export function useQuery<TResult = unknown, TError = unknown>(
   queryKey: QueryKey,
@@ -38,10 +43,6 @@ export function useQuery<TResult = unknown, TError = unknown>(
   queryConfig?: QueryConfig<TResult, TError>
 ): QueryResult<TResult, TError>
 
-// Object syntax
-export function useQuery<TResult = unknown, TError = unknown>(
-  config: UseQueryObjectConfig<TResult, TError>
-): QueryResult<TResult, TError>
 
 // Implementation
 export function useQuery<TResult, TError>(


### PR DESCRIPTION
> change the order of overridden functions so that correct type inference is picked for **Object syntax**


```

// **A)** Parameter syntax with optional config
export function useQuery<TResult = unknown, TError = unknown>(
  queryKey: QueryKey,
  queryConfig?: QueryConfig<TResult, TError>
): QueryResult<TResult, TError>

// **B)** Object syntax
export function useQuery<TResult = unknown, TError = unknown>(
  config: UseQueryObjectConfig<TResult, TError>
): QueryResult<TResult, TError>
```

I am using a query builder that creates a typed structure of **config** with generics.

when invoked with useQuery(configThatIsAlreadyTyped), it is picking syntax **A** instead of syntax **B** with Object syntax. 

This is because of the order of overridden methods. By changing the order the correct type is picked
