### PR TITLE
fix(hydration): set fetchMeta to null by default to make it serializable

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -439,7 +439,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
       errorUpdateCount: 0,
       errorUpdatedAt: 0,
       fetchFailureCount: 0,
-      fetchMeta: undefined,
+      fetchMeta: null,
       isFetching: false,
       isInvalidated: false,
       isPaused: false,
@@ -471,7 +471,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
         return {
           ...state,
           fetchFailureCount: 0,
-          fetchMeta: action.meta,
+          fetchMeta: action.meta ?? null,
           isFetching: true,
           isPaused: false,
           status: state.status === 'idle' ? 'loading' : state.status,


### PR DESCRIPTION
Fixes #1370 

Although it seems to fix the issue, nothing makes sure that this value is not set to `undefined` elsewhere in the code (or prevent to set it in the future) since it's typed as `any`.

What do you think about introducing a [JsonValue](https://github.com/sindresorhus/type-fest/blob/master/source/basic.d.ts#L53) type for values that must be serializable?
