### PR TITLE
fix: typo infinite instead of ininite

### DIFF
--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -71,7 +71,7 @@ const queryClient = new QueryClient({
 
 Query functions now get a `QueryFunctionContext` instead of the query key parameters.
 
-The `QueryFunctionContext` contains a `queryKey` and a `pageParam` in case of ininite queries.
+The `QueryFunctionContext` contains a `queryKey` and a `pageParam` in case of infinite queries.
 
 useQuery:
 


### PR DESCRIPTION
Hello! I found a typo while reading the documentation.