### PR TITLE
docs: fix typos in migration and queries guide

### DIFF
--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -274,7 +274,7 @@ The `ReactQueryCacheProvider` component has been replaced by the `QueryClientPro
 
 ### makeQueryCache()
 
-The `makeQueryCache()` function has replaced by `new QueryCache()`.
+The `makeQueryCache()` function has been replaced by `new QueryCache()`.
 
 ### ReactQueryErrorResetBoundary
 

--- a/docs/src/pages/guides/queries.md
+++ b/docs/src/pages/guides/queries.md
@@ -32,10 +32,10 @@ const result = useQuery('todos', fetchTodoList)
 
 The `result` object contains a few very important states you'll need to be aware of to be productive. A query can only be in one of the following states at any given moment:
 
-- `isLoading` or `status === 'loading' - The query has no data and is currently fetching
+- `isLoading` or `status === 'loading'` - The query has no data and is currently fetching
 - `isError` or `status === 'error'` - The query encountered an error
-- `isSuccess` or `status === 'success' - The query was successful and data is available
-- `isIdle` or `status === 'idle' - The query is currently disabled (you'll learn more about this in a bit)
+- `isSuccess` or `status === 'success'` - The query was successful and data is available
+- `isIdle` or `status === 'idle'` - The query is currently disabled (you'll learn more about this in a bit)
 
 Beyond those primary state, more information is available depending on the state the query:
 
@@ -43,7 +43,7 @@ Beyond those primary state, more information is available depending on the state
 - `data` - If the query is in a `success` state, the data is available via the `data` property.
 - `isFetching` - In any state, if the query is fetching at any time (including background refetching) `isFetching` will be `true`.
 
-For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is avaiable and render the successful state:
+For **most** queries, it's usually sufficient to check for the `isLoading` state, then the `isError` state, then finally, assume that the data is available and render the successful state:
 
 ```js
 function Todos() {


### PR DESCRIPTION
Fix typos in guides/migrating-to-react-query-3 and guides/queries.

Fixes #1378