### PR TITLE
docs: make hook return all necessary variables

### DIFF
--- a/docs/src/pages/docs/guides/testing.md
+++ b/docs/src/pages/docs/guides/testing.md
@@ -55,8 +55,7 @@ Given the following custom hook:
 
 ```
 function useFetchData() {
-  const { data } = useQuery('fetchData', () => request('/api/data'));
-  return data;
+  return useQuery('fetchData', () => request('/api/data'));
 }
 ```
 
@@ -85,7 +84,7 @@ await waitFor(() => {
 expect(result.current).toEqual({answer: 42});
 ```
 
-Here we are making use of `waitFor` and waiting until our Nock expectation indicates that it has been called. This way we know that our hook has finished and should have the correct data.
+Here we are making use of `waitFor` and waiting until our the query status indicates that the request has succeeded. This way we know that our hook has finished and should have the correct data.
 
 ## Testing Load More / Infinite Scroll
 


### PR DESCRIPTION
The first draft of #1244 was waiting for the nock expectation. But it was later changed to use the useQuery's isSuccess variable. This PR makes it explicit.