### PR TITLE
docs(typos): fix typos in mutations guide

### DIFF
--- a/docs/src/pages/guides/mutations.md
+++ b/docs/src/pages/guides/mutations.md
@@ -39,10 +39,10 @@ function App() {
 
 A mutation can only be in one of the following states at any given moment:
 
-- `isIdle` or `status === 'idle' - The mutation is currently idle or in a fresh/reset state
-- `isLoading` or `status === 'loading' - The mutation is currently running
+- `isIdle` or `status === 'idle'` - The mutation is currently idle or in a fresh/reset state
+- `isLoading` or `status === 'loading'` - The mutation is currently running
 - `isError` or `status === 'error'` - The mutation encountered an error
-- `isSuccess` or `status === 'success' - The mutation was successful and mutation data is available
+- `isSuccess` or `status === 'success'` - The mutation was successful and mutation data is available
 
 Beyond those primary state, more information is available depending on the state the mutation:
 


### PR DESCRIPTION
Fix typos in guides/mutations.