### PR TITLE
docs: fix example in defaultQueryFn guide page

### DIFF
--- a/docs/src/pages/guides/default-query-function.md
+++ b/docs/src/pages/guides/default-query-function.md
@@ -7,10 +7,10 @@ If you find yourself wishing for whatever reason that you could just share the s
 
 ```js
 // Define a default query function that will receive the query key
-const defaultQueryFn = async key => {
-  const { data } = await axios.get(`https://jsonplaceholder.typicode.com${key}`)
-  return data
-}
+const defaultQueryFn = async ({ queryKey }) => {
+  const { data } = await axios.get(`https://jsonplaceholder.typicode.com${queryKey[0]}`);
+  return data;
+};
 
 // provide the default query function to your app with defaultOptions
 const queryClient = new QueryClient({


### PR DESCRIPTION
Unfortunately the example on the `defaultQueryFn` guide page doesn't appear to work as-written for `v3.2.0`, but the example in `examples/default-query-function` _does_ work. 

This PR aims to fix this minor inconsistency in the docs.

Thanks for your work on this library -- it's extremely useful!