### PR TITLE
feat: list of queries and mutations to be prevented from being persisted

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "match-sorter": "^6.0.2"
+    "match-sorter": "^6.0.2",
+    "deep-equal": "^2.0.5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0"
@@ -116,6 +117,7 @@
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-terser": "^6.1.0",
     "rollup-plugin-visualizer": "^4.0.4",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "@types/deep-equal": "^1.0.1"
   }
 }


### PR DESCRIPTION
should be able to pass an array of QueryKeys and MutationKeys to be prevented from persisting, a use case that this should be handy its when we querying an access token, this token shouldn't be stored locally since it's not encrypted