### PR TITLE
fix: infer result data type from query fn return type instead of the reverse

### DIFF
--- a/src/core/infiniteQueryObserver.ts
+++ b/src/core/infiniteQueryObserver.ts
@@ -18,14 +18,14 @@ type InfiniteQueryObserverListener<TData, TError> = (
 ) => void
 
 export class InfiniteQueryObserver<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
 > extends QueryObserver<
-  InfiniteData<TData>,
-  TError,
   TQueryFnData,
+  TError,
+  InfiniteData<TData>,
   InfiniteData<TQueryData>
 > {
   // Type override
@@ -45,9 +45,9 @@ export class InfiniteQueryObserver<
   constructor(
     client: QueryClient,
     options: InfiniteQueryObserverOptions<
-      TData,
-      TError,
       TQueryFnData,
+      TError,
+      TData,
       TQueryData
     >
   ) {
@@ -62,15 +62,15 @@ export class InfiniteQueryObserver<
 
   setOptions(
     options?: InfiniteQueryObserverOptions<
-      TData,
-      TError,
       TQueryFnData,
+      TError,
+      TData,
       TQueryData
     >
   ): void {
     super.setOptions({
       ...options,
-      behavior: infiniteQueryBehavior<TData, TError, TQueryFnData>(),
+      behavior: infiniteQueryBehavior<TQueryFnData, TError, TData>(),
     })
   }
 

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -22,12 +22,12 @@ import { Retryer, CancelOptions, isCancelledError } from './retryer'
 
 // TYPES
 
-interface QueryConfig<TData, TError, TQueryFnData> {
+interface QueryConfig<TQueryFnData, TError, TData> {
   cache: QueryCache
   queryKey: QueryKey
   queryHash: string
-  options?: QueryOptions<TData, TError, TQueryFnData>
-  defaultOptions?: QueryOptions<TData, TError, TQueryFnData>
+  options?: QueryOptions<TQueryFnData, TError, TData>
+  defaultOptions?: QueryOptions<TQueryFnData, TError, TData>
   state?: QueryState<TData, TError>
 }
 
@@ -46,20 +46,20 @@ export interface QueryState<TData = unknown, TError = unknown> {
   status: QueryStatus
 }
 
-export interface FetchContext<TData, TError, TQueryFnData> {
+export interface FetchContext<TQueryFnData, TError, TData> {
   fetchFn: () => unknown | Promise<unknown>
   fetchOptions?: FetchOptions
-  options: QueryOptions<TData, TError, TQueryFnData>
+  options: QueryOptions<TQueryFnData, TError, TData>
   queryKey: QueryKey
   state: QueryState<TData, TError>
 }
 
 export interface QueryBehavior<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 > {
-  onFetch: (context: FetchContext<TData, TError, TQueryFnData>) => void
+  onFetch: (context: FetchContext<TQueryFnData, TError, TData>) => void
 }
 
 export interface FetchOptions {
@@ -120,10 +120,14 @@ export type Action<TData, TError> =
 
 // CLASS
 
-export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
+export class Query<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData
+> {
   queryKey: QueryKey
   queryHash: string
-  options!: QueryOptions<TData, TError, TQueryFnData>
+  options!: QueryOptions<TQueryFnData, TError, TData>
   initialState: QueryState<TData, TError>
   state: QueryState<TData, TError>
   cacheTime!: number
@@ -133,9 +137,9 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
   private gcTimeout?: number
   private retryer?: Retryer<unknown, TError>
   private observers: QueryObserver<any, any, any, any>[]
-  private defaultOptions?: QueryOptions<TData, TError, TQueryFnData>
+  private defaultOptions?: QueryOptions<TQueryFnData, TError, TData>
 
-  constructor(config: QueryConfig<TData, TError, TQueryFnData>) {
+  constructor(config: QueryConfig<TQueryFnData, TError, TData>) {
     this.defaultOptions = config.defaultOptions
     this.setOptions(config.options)
     this.observers = []
@@ -148,7 +152,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
   }
 
   private setOptions(
-    options?: QueryOptions<TData, TError, TQueryFnData>
+    options?: QueryOptions<TQueryFnData, TError, TData>
   ): void {
     this.options = { ...this.defaultOptions, ...options }
 
@@ -159,7 +163,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
     )
   }
 
-  setDefaultOptions(options: QueryOptions<TData, TError, TQueryFnData>): void {
+  setDefaultOptions(options: QueryOptions<TQueryFnData, TError, TData>): void {
     this.defaultOptions = options
   }
 
@@ -321,7 +325,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
   }
 
   fetch(
-    options?: QueryOptions<TData, TError, TQueryFnData>,
+    options?: QueryOptions<TQueryFnData, TError, TData>,
     fetchOptions?: FetchOptions
   ): Promise<TData> {
     if (this.state.isFetching)
@@ -361,7 +365,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
         : Promise.reject('Missing queryFn')
 
     // Trigger behavior hook
-    const context: FetchContext<TData, TError, TQueryFnData> = {
+    const context: FetchContext<TQueryFnData, TError, TData> = {
       fetchOptions,
       options: this.options,
       queryKey,
@@ -439,7 +443,7 @@ export class Query<TData = unknown, TError = unknown, TQueryFnData = TData> {
   }
 
   protected getDefaultState(
-    options: QueryOptions<TData, TError, TQueryFnData>
+    options: QueryOptions<TQueryFnData, TError, TData>
   ): QueryState<TData, TError> {
     const data =
       typeof options.initialData === 'function'

--- a/src/core/queryCache.ts
+++ b/src/core/queryCache.ts
@@ -31,15 +31,15 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     this.queriesMap = {}
   }
 
-  build<TData, TError, TQueryFnData>(
+  build<TQueryFnData, TError, TData>(
     client: QueryClient,
-    options: QueryOptions<TData, TError, TQueryFnData>,
+    options: QueryOptions<TQueryFnData, TError, TData>,
     state?: QueryState<TData, TError>
-  ): Query<TData, TError, TQueryFnData> {
+  ): Query<TQueryFnData, TError, TData> {
     const hashFn = getQueryKeyHashFn(options)
     const queryKey = options.queryKey!
     const queryHash = options.queryHash ?? hashFn(queryKey)
-    let query = this.get<TData, TError, TQueryFnData>(queryHash)
+    let query = this.get<TQueryFnData, TError, TData>(queryHash)
 
     if (!query) {
       query = new Query({
@@ -88,9 +88,9 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     })
   }
 
-  get<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  get<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
     queryHash: string
-  ): Query<TData, TError, TQueryFnData> | undefined {
+  ): Query<TQueryFnData, TError, TData> | undefined {
     return this.queriesMap[queryHash]
   }
 
@@ -98,10 +98,10 @@ export class QueryCache extends Subscribable<QueryCacheListener> {
     return this.queries
   }
 
-  find<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  find<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
     arg1: QueryKey,
     arg2?: QueryFilters
-  ): Query<TData, TError, TQueryFnData> | undefined {
+  ): Query<TQueryFnData, TError, TData> | undefined {
     const [filters] = parseFilterArgs(arg1, arg2)
     return this.queries.find(query => matchQuery(filters, query))
   }

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -246,24 +246,24 @@ export class QueryClient {
     return promise
   }
 
-  fetchQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
-    options: FetchQueryOptions<TData, TError, TQueryFnData>
+  fetchQuery<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
+    options: FetchQueryOptions<TQueryFnData, TError, TData>
   ): Promise<TData>
-  fetchQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  fetchQuery<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
     queryKey: QueryKey,
-    options?: FetchQueryOptions<TData, TError, TQueryFnData>
+    options?: FetchQueryOptions<TQueryFnData, TError, TData>
   ): Promise<TData>
-  fetchQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  fetchQuery<TQueryFnData = unknown, TError = unknown, TData = TQueryFnData>(
     queryKey: QueryKey,
-    queryFn: QueryFunction<TQueryFnData | TData>,
-    options?: FetchQueryOptions<TData, TError, TQueryFnData>
+    queryFn: QueryFunction<TQueryFnData>,
+    options?: FetchQueryOptions<TQueryFnData, TError, TData>
   ): Promise<TData>
-  fetchQuery<TData, TError, TQueryFnData = TData>(
-    arg1: QueryKey | FetchQueryOptions<TData, TError, TQueryFnData>,
+  fetchQuery<TQueryFnData, TError, TData = TQueryFnData>(
+    arg1: QueryKey | FetchQueryOptions<TQueryFnData, TError, TData>,
     arg2?:
-      | QueryFunction<TQueryFnData | TData>
-      | FetchQueryOptions<TData, TError, TQueryFnData>,
-    arg3?: FetchQueryOptions<TData, TError, TQueryFnData>
+      | QueryFunction<TQueryFnData>
+      | FetchQueryOptions<TQueryFnData, TError, TData>,
+    arg3?: FetchQueryOptions<TQueryFnData, TError, TData>
   ): Promise<TData> {
     const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
     const defaultedOptions = this.defaultQueryOptions(parsedOptions)
@@ -297,30 +297,42 @@ export class QueryClient {
       .catch(noop)
   }
 
-  fetchInfiniteQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
-    options: FetchInfiniteQueryOptions<TData, TError, TQueryFnData>
+  fetchInfiniteQuery<
+    TQueryFnData = unknown,
+    TError = unknown,
+    TData = TQueryFnData
+  >(
+    options: FetchInfiniteQueryOptions<TQueryFnData, TError, TData>
   ): Promise<InfiniteData<TData>>
-  fetchInfiniteQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  fetchInfiniteQuery<
+    TQueryFnData = unknown,
+    TError = unknown,
+    TData = TQueryFnData
+  >(
     queryKey: QueryKey,
-    options?: FetchInfiniteQueryOptions<TData, TError, TQueryFnData>
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData>
   ): Promise<InfiniteData<TData>>
-  fetchInfiniteQuery<TData = unknown, TError = unknown, TQueryFnData = TData>(
+  fetchInfiniteQuery<
+    TQueryFnData = unknown,
+    TError = unknown,
+    TData = TQueryFnData
+  >(
     queryKey: QueryKey,
-    queryFn: QueryFunction<TQueryFnData | TData>,
-    options?: FetchInfiniteQueryOptions<TData, TError, TQueryFnData>
+    queryFn: QueryFunction<TQueryFnData>,
+    options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData>
   ): Promise<InfiniteData<TData>>
-  fetchInfiniteQuery<TData, TError, TQueryFnData = TData>(
-    arg1: QueryKey | FetchInfiniteQueryOptions<TData, TError, TQueryFnData>,
+  fetchInfiniteQuery<TQueryFnData, TError, TData = TQueryFnData>(
+    arg1: QueryKey | FetchInfiniteQueryOptions<TQueryFnData, TError, TData>,
     arg2?:
-      | QueryFunction<TQueryFnData | TData>
-      | FetchInfiniteQueryOptions<TData, TError, TQueryFnData>,
-    arg3?: FetchInfiniteQueryOptions<TData, TError, TQueryFnData>
+      | QueryFunction<TQueryFnData>
+      | FetchInfiniteQueryOptions<TQueryFnData, TError, TData>,
+    arg3?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData>
   ): Promise<InfiniteData<TData>> {
     const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
     parsedOptions.behavior = infiniteQueryBehavior<
-      TData,
+      TQueryFnData,
       TError,
-      TQueryFnData
+      TData
     >()
     return this.fetchQuery(parsedOptions)
   }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -38,15 +38,15 @@ export interface ObserverFetchOptions extends FetchOptions {
 }
 
 export class QueryObserver<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
 > extends Subscribable<QueryObserverListener<TData, TError>> {
-  options: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>
+  options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>
 
   private client: QueryClient
-  private currentQuery!: Query<TQueryData, TError, TQueryFnData>
+  private currentQuery!: Query<TQueryFnData, TError, TQueryData>
   private currentResult!: QueryObserverResult<TData, TError>
   private currentResultState?: QueryState<TQueryData, TError>
   private previousQueryResult?: QueryObserverResult<TData, TError>
@@ -57,7 +57,7 @@ export class QueryObserver<
 
   constructor(
     client: QueryClient,
-    options: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>
+    options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>
   ) {
     super()
 
@@ -144,7 +144,7 @@ export class QueryObserver<
   }
 
   setOptions(
-    options?: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>
+    options?: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>
   ): void {
     const prevOptions = this.options
     const prevQuery = this.currentQuery
@@ -220,7 +220,7 @@ export class QueryObserver<
     })
   }
 
-  getCurrentQuery(): Query<TQueryData, TError, TQueryFnData> {
+  getCurrentQuery(): Query<TQueryFnData, TError, TQueryData> {
     return this.currentQuery
   }
 
@@ -257,7 +257,7 @@ export class QueryObserver<
 
     // Fetch
     let promise: Promise<TQueryData | undefined> = this.currentQuery.fetch(
-      this.options as QueryOptions<TQueryData, TError, TQueryFnData>,
+      this.options as QueryOptions<TQueryFnData, TError, TQueryData>,
       fetchOptions
     )
 
@@ -483,7 +483,7 @@ export class QueryObserver<
       .getQueryCache()
       .build(
         this.client,
-        this.options as QueryOptions<TQueryData, TError, TQueryFnData>
+        this.options as QueryOptions<TQueryFnData, TError, TQueryData>
       )
 
     if (query === prevQuery) {

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -32,7 +32,7 @@ interface Cancelable {
   cancel(): void
 }
 
-function isCancelable(value: any): value is Cancelable {
+export function isCancelable(value: any): value is Cancelable {
   return typeof value?.cancel === 'function'
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -41,9 +41,9 @@ export interface InfiniteData<TData> {
 }
 
 export interface QueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 > {
   /**
    * If `false`, failed queries will not retry by default.
@@ -60,7 +60,7 @@ export interface QueryOptions<
   queryKey?: QueryKey
   queryKeyHashFn?: QueryKeyHashFunction
   initialData?: TData | InitialDataFunction<TData>
-  behavior?: QueryBehavior<TData, TError, TQueryFnData>
+  behavior?: QueryBehavior<TQueryFnData, TError, TData>
   /**
    * Set this to `false` to disable structural sharing between query results.
    * Defaults to `true`.
@@ -80,11 +80,11 @@ export interface QueryOptions<
 }
 
 export interface QueryObserverOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
-> extends QueryOptions<TData, TError, TQueryFnData> {
+> extends QueryOptions<TQueryFnData, TError, TData> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -175,23 +175,23 @@ export interface QueryObserverOptions<
 }
 
 export interface InfiniteQueryObserverOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
 >
   extends QueryObserverOptions<
-    InfiniteData<TData>,
-    TError,
     TQueryFnData,
+    TError,
+    InfiniteData<TData>,
     InfiniteData<TQueryData>
   > {}
 
 export interface FetchQueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
-> extends QueryOptions<TData, TError, TQueryFnData> {
+  TData = TQueryFnData
+> extends QueryOptions<TQueryFnData, TError, TData> {
   /**
    * The time in milliseconds after data is considered stale.
    * If the data is fresh it will be returned from the cache.
@@ -200,10 +200,10 @@ export interface FetchQueryOptions<
 }
 
 export interface FetchInfiniteQueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
-> extends FetchQueryOptions<InfiniteData<TData>, TError, TQueryFnData> {}
+  TData = TQueryFnData
+> extends FetchQueryOptions<TQueryFnData, TError, InfiniteData<TData>> {}
 
 export interface ResultOptions {
   throwOnError?: boolean

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -58,6 +58,22 @@ describe('useQuery', () => {
       // should error when the query function result does not match with the specified type
       // @ts-expect-error
       useQuery<number>(key, () => 'test')
+
+      // it should infer the result type from a generic query function
+      function queryFn<T = string>(): Promise<T> {
+        return Promise.resolve({} as T)
+      }
+
+      const fromGenericQueryFn = useQuery(key, () => queryFn())
+      expectType<string | undefined>(fromGenericQueryFn.data)
+      expectType<unknown>(fromGenericQueryFn.error)
+
+      const fromGenericOptionsQueryFn = useQuery({
+        queryKey: key,
+        queryFn: () => queryFn(),
+      })
+      expectType<string | undefined>(fromGenericOptionsQueryFn.data)
+      expectType<unknown>(fromGenericOptionsQueryFn.error)
     }
   })
 
@@ -175,7 +191,7 @@ describe('useQuery', () => {
     const states: UseQueryResult<undefined, string>[] = []
 
     function Page() {
-      const state = useQuery<undefined, string, [string]>(
+      const state = useQuery<string[], string, undefined>(
         key,
         () => Promise.reject('rejected'),
         {

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -9,28 +9,28 @@ import {
 } from '../core/types'
 
 export interface UseBaseQueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
-> extends QueryObserverOptions<TData, TError, TQueryFnData, TQueryData> {}
+> extends QueryObserverOptions<TQueryFnData, TError, TData, TQueryData> {}
 
 export interface UseQueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
-> extends UseBaseQueryOptions<TData, TError, TQueryFnData> {}
+  TData = TQueryFnData
+> extends UseBaseQueryOptions<TQueryFnData, TError, TData> {}
 
 export interface UseInfiniteQueryOptions<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData,
+  TData = TQueryFnData,
   TQueryData = TQueryFnData
 >
   extends InfiniteQueryObserverOptions<
-    TData,
-    TError,
     TQueryFnData,
+    TError,
+    TData,
     TQueryData
   > {}
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -6,8 +6,8 @@ import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
 import { UseBaseQueryOptions } from './types'
 
-export function useBaseQuery<TData, TError, TQueryFnData, TQueryData>(
-  options: UseBaseQueryOptions<TData, TError, TQueryFnData, TQueryData>,
+export function useBaseQuery<TQueryFnData, TError, TData, TQueryData>(
+  options: UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryData>,
   Observer: typeof QueryObserver
 ) {
   const queryClient = useQueryClient()

--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -8,35 +8,35 @@ import { useBaseQuery } from './useBaseQuery'
 // HOOK
 
 export function useInfiniteQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
-  options: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
 ): UseInfiniteQueryResult<TData, TError>
 export function useInfiniteQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
   queryKey: QueryKey,
-  options?: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
 ): UseInfiniteQueryResult<TData, TError>
 export function useInfiniteQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
   queryKey: QueryKey,
-  queryFn: QueryFunction<TQueryFnData | TData>,
-  options?: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  queryFn: QueryFunction<TQueryFnData>,
+  options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
 ): UseInfiniteQueryResult<TData, TError>
-export function useInfiniteQuery<TData, TError, TQueryFnData = TData>(
-  arg1: QueryKey | UseInfiniteQueryOptions<TData, TError, TQueryFnData>,
+export function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnData>(
+  arg1: QueryKey | UseInfiniteQueryOptions<TQueryFnData, TError, TData>,
   arg2?:
-    | QueryFunction<TQueryFnData | TData>
-    | UseInfiniteQueryOptions<TData, TError, TQueryFnData>,
-  arg3?: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+    | QueryFunction<TQueryFnData>
+    | UseInfiniteQueryOptions<TQueryFnData, TError, TData>,
+  arg3?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
 ): UseInfiniteQueryResult<TData, TError> {
   const options = parseQueryArgs(arg1, arg2, arg3)
   return useBaseQuery(

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -7,35 +7,35 @@ import { useBaseQuery } from './useBaseQuery'
 // HOOK
 
 export function useQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
-  options: UseQueryOptions<TData, TError, TQueryFnData>
+  options: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError>
 export function useQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
   queryKey: QueryKey,
-  options?: UseQueryOptions<TData, TError, TQueryFnData>
+  options?: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError>
 export function useQuery<
-  TData = unknown,
+  TQueryFnData = unknown,
   TError = unknown,
-  TQueryFnData = TData
+  TData = TQueryFnData
 >(
   queryKey: QueryKey,
-  queryFn: QueryFunction<TQueryFnData | TData>,
-  options?: UseQueryOptions<TData, TError, TQueryFnData>
+  queryFn: QueryFunction<TQueryFnData>,
+  options?: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError>
-export function useQuery<TData, TError, TQueryFnData = TData>(
-  arg1: QueryKey | UseQueryOptions<TData, TError, TQueryFnData>,
+export function useQuery<TQueryFnData, TError, TData = TQueryFnData>(
+  arg1: QueryKey | UseQueryOptions<TQueryFnData, TError, TData>,
   arg2?:
-    | QueryFunction<TData | TQueryFnData>
-    | UseQueryOptions<TData, TError, TQueryFnData>,
-  arg3?: UseQueryOptions<TData, TError, TQueryFnData>
+    | QueryFunction<TQueryFnData>
+    | UseQueryOptions<TQueryFnData, TError, TData>,
+  arg3?: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError> {
   const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
   return useBaseQuery(parsedOptions, QueryObserver)


### PR DESCRIPTION
Fix for https://github.com/tannerlinsley/react-query/issues/1445 .

This PR swaps the query result type and query function result type inference. The first generic will now define the query function result type, and then the default query result type is inferred from this instead of the other way around.

Might be good to do a thorough review on this one as it is quite a big change.