### PR TITLE
fix: make sure typed query fn contexts are accepted

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,7 +6,7 @@ import type { QueryFilters } from './utils'
 export type QueryKey = string | unknown[]
 
 export type QueryFunction<T = unknown> = (
-  context: QueryFunctionContext
+  context: QueryFunctionContext<any>
 ) => T | Promise<T>
 
 export interface QueryFunctionContext<

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -1756,24 +1756,26 @@ describe('useQuery', () => {
   it('should not pass stringified variables to query function', async () => {
     const key = queryKey()
     const variables = { number: 5, boolean: false, object: {}, array: [] }
-    const queryFn = jest
-      .fn()
-      .mockImplementation(
-        async (ctx: QueryFunctionContext<[string, typeof variables]>) => {
-          await sleep(10)
-          return ctx.queryKey
-        }
-      )
+    const states: UseQueryResult<[string, typeof variables]>[] = []
+
+    const queryFn = async (
+      ctx: QueryFunctionContext<[string, typeof variables]>
+    ) => {
+      await sleep(10)
+      return ctx.queryKey
+    }
 
     function Page() {
-      useQuery([key, variables], queryFn)
-
+      const state = useQuery([key, variables], queryFn)
+      states.push(state)
       return null
     }
 
     renderWithClient(queryClient, <Page />)
 
-    expect(queryFn).toHaveBeenCalledWith({ queryKey: [key, variables] })
+    await sleep(20)
+
+    expect(states[1].data).toEqual([key, variables])
   })
 
   it('should not refetch query on focus when `enabled` is set to `false`', async () => {


### PR DESCRIPTION
Fixes https://github.com/tannerlinsley/react-query/issues/1462