### PR TITLE
fix: make sure queries are retried after an error boundary reset

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -495,7 +495,7 @@ export class Query<
           fetchMeta: action.meta ?? null,
           isFetching: true,
           isPaused: false,
-          status: state.status === 'idle' ? 'loading' : state.status,
+          status: !state.dataUpdatedAt ? 'loading' : state.status,
         }
       case 'success':
         return {
@@ -514,12 +514,22 @@ export class Query<
         const error = action.error as unknown
 
         if (isCancelledError(error) && error.revert) {
+          let previousStatus: QueryStatus
+
+          if (!state.dataUpdatedAt && !state.errorUpdatedAt) {
+            previousStatus = 'idle'
+          } else if (state.dataUpdatedAt > state.errorUpdatedAt) {
+            previousStatus = 'success'
+          } else {
+            previousStatus = 'error'
+          }
+
           return {
             ...state,
             fetchFailureCount: 0,
             isFetching: false,
             isPaused: false,
-            status: state.status === 'loading' ? 'idle' : state.status,
+            status: previousStatus,
           }
         }
 

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -96,7 +96,12 @@ export class QueryObserver<
 
   willLoadOnMount(): boolean {
     return (
-      this.options.enabled !== false && !this.currentQuery.state.dataUpdatedAt
+      this.options.enabled !== false &&
+      !this.currentQuery.state.dataUpdatedAt &&
+      !(
+        this.currentQuery.state.status === 'error' &&
+        this.options.retryOnMount === false
+      )
     )
   }
 
@@ -354,7 +359,7 @@ export class QueryObserver<
     // Optimistically set status to loading if we will start fetching
     if (willFetch) {
       isFetching = true
-      if (status === 'idle') {
+      if (!dataUpdatedAt) {
         status = 'loading'
       }
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -128,6 +128,11 @@ export interface QueryObserverOptions<
    */
   refetchOnMount?: boolean | 'always'
   /**
+   * If set to `false`, the query will not be retried on mount if it contains an error.
+   * Defaults to `true`.
+   */
+  retryOnMount?: boolean
+  /**
    * If set, the component will only re-render if any of the listed properties change.
    * When set to `['data', 'error']`, the component will only re-render when the `data` or `error` properties change.
    */


### PR DESCRIPTION
This PR contains two fixes:
- Always set query in `loading` state when fetching and no data is cached.
- Make sure components suspend and error when needed.

Fixes https://github.com/tannerlinsley/react-query/issues/1471