### PR TITLE
feat: options.initialDataUpdatedAt

### DIFF
--- a/docs/src/pages/guides/initial-query-data.md
+++ b/docs/src/pages/guides/initial-query-data.md
@@ -25,11 +25,11 @@ function Todos() {
 }
 ```
 
-### `initialDataUpdatedAt` and `staleTime`
+### `staleTime` and `initialDataUpdatedAt`
 
 By default, `initialData` is treated as totally fresh, as if it were just fetched. This also means that it will affect how it is interpreted by the `staleTime` option.
 
-- If you configure your query observer with `initialData`, but no `staleTime`, the query will immediately refetch when it mounts, since the default `staleTime` is `0`:
+- If you configure your query observer with `initialData`, and no `staleTime` (the default `staleTime: 0`), the query will immediately refetch when it mounts:
 
   ```js
   function Todos() {
@@ -40,7 +40,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   }
   ```
 
-- Alternatively if you configure your query observer with a `staleTime` of `1000` ms, for example, the `initialData` you provide will be considered fresh for that same amount of time, as if it was just fetched from your query function.
+- If you configure your query observer with `initialData` and a `staleTime` of `1000` ms, the data will be considered fresh for that same amount of time, as if it was just fetched from your query function.
 
   ```js
   function Todos() {
@@ -52,9 +52,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   }
   ```
 
-  This above a simple way to avoid refetching immediately after the component mounts, however, this means that even after the initialData is used, you will still have a staleTime for future queries.
-
-- For the most effective setup, another option called `initialDataUpdatedAt` is available which allows you to pass a numeric unix timestamp of when the initialData itself was last updated.
+- So what if your `initialData` isn't totally fresh? That leaves us with the last configuration that is actually the most accurate and uses an option called `initialDataUpdatedAt`. This options allows you to pass a numeric unix timestamp of when the initialData itself was last updated.
   ```js
   function Todos() {
     // Show initialTodos immeidately, but won't refetch until another interaction event is encountered after 1000 ms
@@ -62,11 +60,11 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
       initialData: initialTodos,
       staleTime: 60 * 1000 // 1 minute
       // This could be 10 seconds ago or 10 minutes ago
-      initialDataUpdatedAt: 1608412420052
+      initialDataUpdatedAt: initialTodosUpdatedTimestamp // eg. 1608412420052
     })
   }
   ```
-  This option allows the staleTime to be used for it's original purpose, determining how fresh the data needs to be, instead of being used simply to combat an initialData that is considered fresh immediately. In the example above, the staleTime is deliberately set to 1 minute, and we can hint to the query when the initialData was last updated so the query can then decide for itself whether the data needs to be refetched again or not.
+  This option allows the staleTime to be used for it's original purpose, determining how fresh the data needs to be, while also allowing the data to be refetched on mount if the `initialData` is older than the `staleTime`. In the example above, our data needs to be fresh within 1 minute, and we can hint to the query when the initialData was last updated so the query can decide for itself whether the data needs to be refetched again or not.
 
 > If you would rather treat your data as **prefetched data**, we recommend that you use the `prefetchQuery` or `fetchQuery` APIs to populate the cache beforehand, thus letting you configure your `staleTime` independently from your initialData
 

--- a/docs/src/pages/guides/initial-query-data.md
+++ b/docs/src/pages/guides/initial-query-data.md
@@ -25,20 +25,48 @@ function Todos() {
 }
 ```
 
-### Initial Data and `staleTime`
+### `initialDataUpdatedAt` and `staleTime`
 
-`initialData` is treated exactly the same as normal data, which means that is follows the same rules and expectations of `staleTime`.
+By default, `initialData` is treated as totally fresh, as if it were just fetched. This also means that it will affect how it is interpreted by the `staleTime` option.
 
-- If you configure your query observer with a `staleTime` of `10000`, for example, the `initialData` you provide will be considered fresh for that same amount of time, just like your normal data.
+- If you configure your query observer with `initialData`, but no `staleTime`, the query will immediately refetch when it mounts, since the default `staleTime` is `0`:
 
-```js
-function Todos() {
-  const result = useQuery('todos', () => fetch('/todos'), {
-    initialData: initialTodos,
-    staleTime: 10000,
-  })
-}
-```
+  ```js
+  function Todos() {
+    // Will show initialTodos immediately, but also immediately refetch todos after mount
+    const result = useQuery('todos', () => fetch('/todos'), {
+      initialData: initialTodos,
+    })
+  }
+  ```
+
+- Alternatively if you configure your query observer with a `staleTime` of `1000` ms, for example, the `initialData` you provide will be considered fresh for that same amount of time, as if it was just fetched from your query function.
+
+  ```js
+  function Todos() {
+    // Show initialTodos immeidately, but won't refetch until another interaction event is encountered after 1000 ms
+    const result = useQuery('todos', () => fetch('/todos'), {
+      initialData: initialTodos,
+      staleTime: 1000,
+    })
+  }
+  ```
+
+  This above a simple way to avoid refetching immediately after the component mounts, however, this means that even after the initialData is used, you will still have a staleTime for future queries.
+
+- For the most effective setup, another option called `initialDataUpdatedAt` is available which allows you to pass a numeric unix timestamp of when the initialData itself was last updated.
+  ```js
+  function Todos() {
+    // Show initialTodos immeidately, but won't refetch until another interaction event is encountered after 1000 ms
+    const result = useQuery('todos', () => fetch('/todos'), {
+      initialData: initialTodos,
+      staleTime: 60 * 1000 // 1 minute
+      // This could be 10 seconds ago or 10 minutes ago
+      initialDataUpdatedAt: 1608412420052
+    })
+  }
+  ```
+  This option allows the staleTime to be used for it's original purpose, determining how fresh the data needs to be, instead of being used simply to combat an initialData that is considered fresh immediately. In the example above, the staleTime is deliberately set to 1 minute, and we can hint to the query when the initialData was last updated so the query can then decide for itself whether the data needs to be refetched again or not.
 
 > If you would rather treat your data as **prefetched data**, we recommend that you use the `prefetchQuery` or `fetchQuery` APIs to populate the cache beforehand, thus letting you configure your `staleTime` independently from your initialData
 
@@ -71,7 +99,24 @@ function Todo({ todoId }) {
 }
 ```
 
-Most of the time, this pattern works well, but if the source query you're using to look up the initial data from is old, you may not want to use the data at all and just fetch from the server. To make this decision easier, you can use the `queryClient.getQueryState` method instead to get more information about the source query, including a `state.dataUpdatedAt` timestamp you can use to decide if the query is "fresh" enough for your needs:
+### Initial Data from the cache with `initialDataUpdatedAt`
+
+Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData` Instead of using an artificial `staleTime` to keep your query from refetching immediately, it's suggested that you pass the source query's `dataUpdatedAt` to `initialDataUpdatedAt`. This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
+
+```js
+function Todo({ todoId }) {
+  const result = useQuery(['todo', todoId], () => fetch('/todos'), {
+    initialData: () =>
+      queryClient.getQueryData('todos')?.find(d => d.id === todoId),
+    initialDataUpdatedAt: () =>
+      queryClient.getQueryState('todos')?.dataUpdatedAt,
+  })
+}
+```
+
+### Conditional Initial Data from Cache
+
+If the source query you're using to look up the initial data from is old, you may not want to use the cached data at all and just fetch from the server. To make this decision easier, you can use the `queryClient.getQueryState` method instead to get more information about the source query, including a `state.dataUpdatedAt` timestamp you can use to decide if the query is "fresh" enough for your needs:
 
 ```js
 function Todo({ todoId }) {
@@ -86,7 +131,7 @@ function Todo({ todoId }) {
         return state.data.find(d => d.id === todoId)
       }
 
-      // Otherwise, return undefined and let it fetch!
+      // Otherwise, return undefined and let it fetch from a hard loading state!
     },
   })
 }

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -450,12 +450,20 @@ export class Query<
         ? (options.initialData as InitialDataFunction<TData>)()
         : options.initialData
 
+    const hasInitialData = typeof options.initialData !== 'undefined'
+
+    const initialDataUpdatedAt =
+      hasInitialData &&
+      (typeof options.initialDataUpdatedAt === 'function'
+        ? (options.initialDataUpdatedAt as () => number | undefined)()
+        : options.initialDataUpdatedAt)
+
     const hasData = typeof data !== 'undefined'
 
     return {
       data,
       dataUpdateCount: 0,
-      dataUpdatedAt: hasData ? Date.now() : 0,
+      dataUpdatedAt: hasData ? initialDataUpdatedAt || Date.now() : 0,
       error: null,
       errorUpdateCount: 0,
       errorUpdatedAt: 0,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -60,6 +60,7 @@ export interface QueryOptions<
   queryKey?: QueryKey
   queryKeyHashFn?: QueryKeyHashFunction
   initialData?: TData | InitialDataFunction<TData>
+  initialDataUpdatedAt?: number | (() => number | undefined)
   behavior?: QueryBehavior<TQueryFnData, TError, TData>
   /**
    * Set this to `false` to disable structural sharing between query results.

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -2101,6 +2101,44 @@ describe('useQuery', () => {
     })
   })
 
+  it('should fetch if initial data updated at is older than stale time', async () => {
+    const key = queryKey()
+    const states: UseQueryResult<string>[] = []
+
+    const oneSecondAgo = Date.now() - 1000
+
+    function Page() {
+      const state = useQuery(key, () => 'data', {
+        staleTime: 50,
+        initialData: 'initial',
+        initialDataUpdatedAt: oneSecondAgo,
+      })
+      states.push(state)
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(100)
+
+    expect(states.length).toBe(3)
+    expect(states[0]).toMatchObject({
+      data: 'initial',
+      isStale: true,
+      isFetching: true,
+    })
+    expect(states[1]).toMatchObject({
+      data: 'data',
+      isStale: false,
+      isFetching: false,
+    })
+    expect(states[2]).toMatchObject({
+      data: 'data',
+      isStale: true,
+      isFetching: false,
+    })
+  })
+
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
     const states: UseQueryResult<{ count: number }>[] = []


### PR DESCRIPTION
Adds an `initialDataUpdatedAt` option to the query options. This allows initialData to be "tagged" with an updatedAt timestamp. Previously, it was possible for old initialData to be considered fresh if a `staleTime` was also provided to the query. Now, you can easily use both `initialData` and `staleTime` together without this edge case.

- [x] Docs
- [x] Tests