### PR TITLE
feat(types): useQueries to flow through types

### DIFF
--- a/docs/src/pages/reference/useQueries.md
+++ b/docs/src/pages/reference/useQueries.md
@@ -19,3 +19,40 @@ The `useQueries` hook accepts an array with query option objects identical to th
 **Returns**
 
 The `useQueries` hook returns an array with all the query results.
+
+Proposed docs to add to the `useQueries` page:
+
+**TypeScript users**
+
+If you're using `react-query` with TypeScript then you'll be able to benefit from type inference:
+
+```ts
+const resultWithAllTheSameTypes = useQueries(
+  [1, 2].map(x => ({ queryKey: `${x}`, queryFn: () => x }))
+)
+// resultWithAllTheSameTypes: QueryObserverResult<number, unknown>[]
+
+const resultWithDifferentTypes = useQueries(
+  [1, 'two', new Date()].map(x => ({ queryKey: `${x}`, queryFn: () => x }))
+)
+// resultWithDifferentTypes: QueryObserverResult<string | number | Date, unknown>[]
+```
+
+In both the examples above, no types were specified and the compiler correctly inferred the types from the array passed to `useQueries`.
+
+However, if you pass an array literal *where different elements have a `queryFn` with differing return types* then the compiler will be able to correctly infer the positional types. Consider:
+
+```ts
+const resultWithoutUsingMap = useQueries([
+  { queryKey: key1, queryFn: () => 1 },
+  { queryKey: key2, queryFn: () => 'two' },
+])
+
+if (result[0].data) {
+  const isANumber: number = result[0].data
+}
+if (result[1].data) {
+  const isAString: string = result[1].data
+}
+```
+

--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -5,15 +5,26 @@ import type { QueryClient } from './queryClient'
 import { QueryObserver } from './queryObserver'
 import { Subscribable } from './subscribable'
 
-type QueriesObserverListener = (result: QueryObserverResult[]) => void
-
-export class QueriesObserver extends Subscribable<QueriesObserverListener> {
+export class QueriesObserver<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData
+> extends Subscribable<(result: QueryObserverResult<TData, TError>[]) => void> {
   private client: QueryClient
-  private result: QueryObserverResult[]
-  private queries: QueryObserverOptions[]
-  private observers: QueryObserver[]
+  private result: QueryObserverResult<TData, TError>[]
+  private queries: QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData
+  >[]
+  private observers: QueryObserver<TQueryFnData, TError, TData, TQueryData>[]
 
-  constructor(client: QueryClient, queries?: QueryObserverOptions[]) {
+  constructor(
+    client: QueryClient,
+    queries?: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>[]
+  ) {
     super()
 
     this.client = client
@@ -48,12 +59,14 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     })
   }
 
-  setQueries(queries: QueryObserverOptions[]): void {
+  setQueries(
+    queries: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>[]
+  ): void {
     this.queries = queries
     this.updateObservers()
   }
 
-  getCurrentResult(): QueryObserverResult[] {
+  getCurrentResult(): QueryObserverResult<TData, TError>[] {
     return this.result
   }
 
@@ -62,7 +75,9 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
 
     const prevObservers = this.observers
     const newObservers = this.queries.map((options, i) => {
-      let observer: QueryObserver | undefined = prevObservers[i]
+      let observer:
+        | QueryObserver<TQueryFnData, TError, TData, TQueryData>
+        | undefined = prevObservers[i]
 
       const defaultedOptions = this.client.defaultQueryObserverOptions(options)
       const hashFn = getQueryKeyHashFn(defaultedOptions)
@@ -110,7 +125,10 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     this.notify()
   }
 
-  private onUpdate(observer: QueryObserver, result: QueryObserverResult): void {
+  private onUpdate(
+    observer: QueryObserver<TQueryFnData, TError, TData, TQueryData>,
+    result: QueryObserverResult<TData, TError>
+  ): void {
     const index = this.observers.indexOf(observer)
     if (index !== -1) {
       this.result = replaceAt(this.result, index, result)

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react'
 
-import {
-  expectType,
-  queryKey,
-  renderWithClient,
-  sleep,
-} from './utils'
+import { expectType, queryKey, renderWithClient, sleep } from './utils'
 import { useQueries, QueryClient, UseQueryResult, QueryCache } from '../..'
 
 describe('useQueries', () => {
@@ -74,6 +69,36 @@ describe('useQueries', () => {
       }
       if (result[1].data) {
         expectType<string>(result[1].data)
+      }
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(10)
+  })
+
+  it('if select is provided then the return type should be unknown (a type test; validated by successful compilation; not runtime results)', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+
+    function Page() {
+      const result = useQueries([
+        {
+          queryKey: key1,
+          queryFn: () => ({ prop: 'value' }),
+          // here x is unknown; we use x.prop without testing - triggering `Object is of type 'unknown'.ts(2571)`
+          // @ts-expect-error
+          select: x => x.prop,
+        },
+        { queryKey: key2, queryFn: () => 1 },
+      ])
+
+      if (result[0].data) {
+        expectType<unknown>(result[0].data)
+      }
+      if (result[1].data) {
+        expectType<number>(result[1].data)
       }
       return null
     }

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -42,6 +42,6 @@ describe('useQueries', () => {
       [1, 2, 3].map(num => ({ queryKey: queryKey(), queryFn: () => num }))
     )
 
-    expect(results.length).toBe(2)
+    expect(results.length).toBe(3)
   })
 })

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -78,27 +78,36 @@ describe('useQueries', () => {
     await sleep(10)
   })
 
-  it('if select is provided then the return type should be unknown (a type test; validated by successful compilation; not runtime results)', async () => {
+  it('if select is provided then the return type should flow from that (a type test; validated by successful compilation; not runtime results)', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
+    const key3 = queryKey()
 
     function Page() {
       const result = useQueries([
         {
           queryKey: key1,
           queryFn: () => ({ prop: 'value' }),
+          select: x => x,
+        },
+        {
+          queryKey: key2,
+          queryFn: () => ({ prop: 'value' }),
           // here x is unknown; we use x.prop without testing - triggering `Object is of type 'unknown'.ts(2571)`
           // @ts-expect-error
-          select: x => x.prop,
+          select: x => x.prop as string,
         },
-        { queryKey: key2, queryFn: () => 1 },
+        { queryKey: key3, queryFn: () => 1 },
       ])
 
       if (result[0].data) {
         expectType<unknown>(result[0].data)
       }
       if (result[1].data) {
-        expectType<number>(result[1].data)
+        expectType<string>(result[1].data)
+      }
+      if (result[2].data) {
+        expectType<number>(result[2].data)
       }
       return null
     }

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 
 import { queryKey, renderWithClient, sleep } from './utils'
-import { useQueries, QueryClient, UseQueryResult, QueryCache } from '../..'
+import {
+  useQueries,
+  QueryClient,
+  UseQueryResult,
+  QueryCache,
+  QueryObserverResult,
+} from '../..'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()
@@ -29,5 +35,13 @@ describe('useQueries', () => {
     expect(results[0]).toMatchObject([{ data: undefined }, { data: undefined }])
     expect(results[1]).toMatchObject([{ data: 1 }, { data: undefined }])
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
+  })
+
+  it('should flow through data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
+    const results: QueryObserverResult<number, Error>[] = useQueries<number, Error>(
+      [1, 2, 3].map(num => ({ queryKey: queryKey(), queryFn: () => num }))
+    )
+
+    expect(results.length).toBe(2)
   })
 })

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -6,7 +6,6 @@ import {
   QueryClient,
   UseQueryResult,
   QueryCache,
-  QueryObserverResult,
 } from '../..'
 
 describe('useQueries', () => {
@@ -37,17 +36,46 @@ describe('useQueries', () => {
     expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
   })
 
-  it('should flow through data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
+  it('should return same data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
-    const results = [];
+    const results: number[] = [];
 
     function Page() {
-      const result: QueryObserverResult<number, Error>[] = useQueries<number, Error>([
+      const result = useQueries([
         { queryKey: key1, queryFn: () => 1 },
         { queryKey: key2, queryFn: () => 2 },
       ])
-      results.push(...result);
+      if (result[0].data) {
+        results.push(result[0].data)
+      }
+      if (result[1].data) {
+        results.push(result[1].data)
+      }
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(10)
+  })
+
+  it('should return different data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const results: (number | string)[] = [];
+
+    function Page() {
+      const result = useQueries<number | string>([
+        { queryKey: key1, queryFn: () => 1 },
+        { queryKey: key2, queryFn: () => 'two' },
+      ])
+      if (result[0].data) {
+        results.push(result[0].data)
+      }
+      if (result[1].data) {
+        results.push(result[1].data)
+      }
       return null
     }
 

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { queryKey, renderWithClient, sleep } from './utils'
 import {
-  useQueries,
-  QueryClient,
-  UseQueryResult,
-  QueryCache,
-} from '../..'
+  expectType,
+  queryKey,
+  renderWithClient,
+  sleep,
+} from './utils'
+import { useQueries, QueryClient, UseQueryResult, QueryCache } from '../..'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()
@@ -39,7 +39,7 @@ describe('useQueries', () => {
   it('should return same data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
-    const results: number[] = [];
+    const results: number[] = []
 
     function Page() {
       const result = useQueries([
@@ -63,18 +63,17 @@ describe('useQueries', () => {
   it('should return different data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
     const key1 = queryKey()
     const key2 = queryKey()
-    const results: (number | string)[] = [];
 
     function Page() {
-      const result = useQueries<number | string>([
+      const result = useQueries([
         { queryKey: key1, queryFn: () => 1 },
         { queryKey: key2, queryFn: () => 'two' },
       ])
       if (result[0].data) {
-        results.push(result[0].data)
+        expectType<number>(result[0].data)
       }
       if (result[1].data) {
-        results.push(result[1].data)
+        expectType<string>(result[1].data)
       }
       return null
     }

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -38,10 +38,21 @@ describe('useQueries', () => {
   })
 
   it('should flow through data types correctly (a type test; validated by successful compilation; not runtime results)', async () => {
-    const results: QueryObserverResult<number, Error>[] = useQueries<number, Error>(
-      [1, 2, 3].map(num => ({ queryKey: queryKey(), queryFn: () => num }))
-    )
+    const key1 = queryKey()
+    const key2 = queryKey()
+    const results = [];
 
-    expect(results.length).toBe(3)
+    function Page() {
+      const result: QueryObserverResult<number, Error>[] = useQueries<number, Error>([
+        { queryKey: key1, queryFn: () => 1 },
+        { queryKey: key2, queryFn: () => 2 },
+      ])
+      results.push(...result);
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(10)
   })
 })

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -11,11 +11,15 @@ export function useQueries<TQueries extends readonly UseQueryOptions[]>(
   queries: [...TQueries]
 ): {
   [ArrayElement in keyof TQueries]: UseQueryResult<
-    Awaited<
-      ReturnType<
-        NonNullable<Extract<TQueries[ArrayElement], UseQueryOptions>['queryFn']>
-      >
-    >
+    TQueries[ArrayElement] extends { select: any }
+      ? unknown
+      : Awaited<
+          ReturnType<
+            NonNullable<
+              Extract<TQueries[ArrayElement], UseQueryOptions>['queryFn']
+            >
+          >
+        >
   >
 } {
   const queryClient = useQueryClient()

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -11,8 +11,10 @@ export function useQueries<TQueries extends readonly UseQueryOptions[]>(
   queries: [...TQueries]
 ): {
   [ArrayElement in keyof TQueries]: UseQueryResult<
-    TQueries[ArrayElement] extends { select: any }
-      ? unknown
+    TQueries[ArrayElement] extends { select: infer TSelect }
+      ? TSelect extends (data: any) => any
+        ? ReturnType<TSelect>
+        : never
       : Awaited<
           ReturnType<
             NonNullable<

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -5,13 +5,22 @@ import { QueriesObserver } from '../core/queriesObserver'
 import { useQueryClient } from './QueryClientProvider'
 import { UseQueryOptions, UseQueryResult } from './types'
 
-export function useQueries(queries: UseQueryOptions[]): UseQueryResult[] {
+export function useQueries<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData
+>(
+  queries: UseQueryOptions<TQueryFnData, TError, TData>[]
+): UseQueryResult<TData, TError>[] {
   const queryClient = useQueryClient()
 
   // Create queries observer
-  const observerRef = React.useRef<QueriesObserver>()
+  const observerRef = React.useRef<
+    QueriesObserver<TQueryFnData, TError, TData>
+  >()
   const observer =
-    observerRef.current || new QueriesObserver(queryClient, queries)
+    observerRef.current ||
+    new QueriesObserver<TQueryFnData, TError, TData>(queryClient, queries)
   observerRef.current = observer
 
   // Update queries


### PR DESCRIPTION
Hello @tannerlinsley!

Merry Christmas and thank you for `react-query`; it's awesome! 🎄 

I've just been trying out `useQueries` in `react-query` 3 and it's really cool!  However one of the things I bumped on was the return type reliably being `QueryObserverResult<unknown, unknown>[]`.  This means I have to assert the type before I can use it.

This can be improved by supporting generics for `useQueries` just as `useQuery` does.  This PR adds that support; very much modelled on the code of `useQuery`.  It also adds a test which asserts that types flow through in the way we'd hope for.

This should be a backwards compatible change; all existing users will be experiencing `QueryObserverResult<unknown, unknown>[]` and then having to subsequently assert types.  That should all still work, but if they would like, they'll no longer need that code.

What do you think?