### PR TITLE
docs: fix initialDataUpdatedAt timestamp information

### DIFF
--- a/docs/src/pages/guides/initial-query-data.md
+++ b/docs/src/pages/guides/initial-query-data.md
@@ -52,7 +52,7 @@ By default, `initialData` is treated as totally fresh, as if it were just fetche
   }
   ```
 
-- So what if your `initialData` isn't totally fresh? That leaves us with the last configuration that is actually the most accurate and uses an option called `initialDataUpdatedAt`. This options allows you to pass a numeric unix timestamp of when the initialData itself was last updated.
+- So what if your `initialData` isn't totally fresh? That leaves us with the last configuration that is actually the most accurate and uses an option called `initialDataUpdatedAt`. This options allows you to pass a numeric JS timestamp in milliseconds of when the initialData itself was last updated, e.g. what `Date.now()` provides. Take note that if you have a unix timestamp, you'll need to convert it to a JS timestamp by multiplying it by `1000`.
   ```js
   function Todos() {
     // Show initialTodos immeidately, but won't refetch until another interaction event is encountered after 1000 ms


### PR DESCRIPTION
The documentation of `initialDataUpdatedAt` added in #1493 erroneously specifies the option as taking a unix timestamp, while it actually takes a JS timestamp.