### PR TITLE
fix: :bug: Make sure queries which have dataUpdatedAt of 0 will be run

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -475,7 +475,11 @@ export class Query<
     return {
       data,
       dataUpdateCount: 0,
-      dataUpdatedAt: hasData ? initialDataUpdatedAt || Date.now() : 0,
+      dataUpdatedAt: !hasData
+        ? 0
+        : typeof initialDataUpdatedAt !== 'number'
+        ? Date.now()
+        : initialDataUpdatedAt,
       error: null,
       errorUpdateCount: 0,
       errorUpdatedAt: 0,

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -464,22 +464,18 @@ export class Query<
 
     const hasInitialData = typeof options.initialData !== 'undefined'
 
-    const initialDataUpdatedAt =
-      hasInitialData &&
-      (typeof options.initialDataUpdatedAt === 'function'
+    const initialDataUpdatedAt = hasInitialData
+      ? typeof options.initialDataUpdatedAt === 'function'
         ? (options.initialDataUpdatedAt as () => number | undefined)()
-        : options.initialDataUpdatedAt)
+        : options.initialDataUpdatedAt
+      : 0
 
     const hasData = typeof data !== 'undefined'
 
     return {
       data,
       dataUpdateCount: 0,
-      dataUpdatedAt: !hasData
-        ? 0
-        : typeof initialDataUpdatedAt !== 'number'
-        ? Date.now()
-        : initialDataUpdatedAt,
+      dataUpdatedAt: hasData ? initialDataUpdatedAt ?? Date.now() : 0,
       error: null,
       errorUpdateCount: 0,
       errorUpdatedAt: 0,

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -2107,6 +2107,37 @@ describe('useQuery', () => {
     })
   })
 
+  it('should fetch if "initial data updated at" is exactly 0', async () => {
+    const key = queryKey()
+    const states: UseQueryResult<string>[] = []
+
+    function Page() {
+      const state = useQuery(key, () => 'data', {
+        staleTime: 10 * 1000, // 10 seconds
+        initialData: 'initial',
+        initialDataUpdatedAt: 0,
+      })
+      states.push(state)
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await sleep(100)
+
+    expect(states.length).toBe(2)
+    expect(states[0]).toMatchObject({
+      data: 'initial',
+      isStale: true,
+      isFetching: true,
+    })
+    expect(states[1]).toMatchObject({
+      data: 'data',
+      isStale: false,
+      isFetching: false,
+    })
+  })
+
   it('should keep initial data when the query key changes', async () => {
     const key = queryKey()
     const states: UseQueryResult<{ count: number }>[] = []


### PR DESCRIPTION
When initialDataUpdatedAt is a falsy numeric value (e.g. 0), it will cause it to be replaced with Date.now(). This leads to unexpected behaviour, as one would expect the query to be invalidated instantly, if staleTime is set to an amount less than the result of Date.now(). This change will check if the value is numeric, and if so, always use this numeric value.

BREAKING: This changes the behaviour of the plugin for those users that have specified initialDataUpdated at <= 0.