### PR TITLE
docs: fix typo on Initial Query Data page

### DIFF
--- a/docs/src/pages/guides/initial-query-data.md
+++ b/docs/src/pages/guides/initial-query-data.md
@@ -6,7 +6,7 @@ title: Initial Query Data
 There are many ways to supply initial data for a query to the cache before you need it:
 
 - Declaratively:
-  - Provide `initialData` to a query to prepopulate the its cache if empty
+  - Provide `initialData` to a query to prepopulate its cache if empty
 - Imperatively:
   - [Prefetch the data using `queryClient.prefetchQuery`](../prefetching)
   - [Manually place the data into the cache using `queryClient.setQueryData`](../prefetching)


### PR DESCRIPTION
✍️ Remove a small typo from the docs