### PR TITLE
Docs: Fixes incorrect prop variable in Todos example

### DIFF
--- a/docs/src/pages/guides/query-keys.md
+++ b/docs/src/pages/guides/query-keys.md
@@ -66,7 +66,7 @@ useQuery(['todos', undefined, page, status], ...)
 Since query keys uniquely describe the data they are fetching, they should include any variables you use in your query function that **change**. For example:
 
 ```js
-function Todos({ completed }) {
+function Todos({ todoId }) {
   const result = useQuery(['todos', todoId], () => fetchTodoById(todoId))
 }
 ```


### PR DESCRIPTION
The prop referenced `completed` But the variable used was `todoId`.