### PR TITLE
fix: prevent missing renders

### DIFF
--- a/src/react/tests/suspense.test.tsx
+++ b/src/react/tests/suspense.test.tsx
@@ -59,7 +59,7 @@ describe("useQuery's in Suspense mode", () => {
 
     await sleep(20)
 
-    expect(renders).toBe(4)
+    expect(renders).toBe(5)
     expect(states.length).toBe(2)
     expect(states[0]).toMatchObject({ data: 1, status: 'success' })
     expect(states[1]).toMatchObject({ data: 2, status: 'success' })

--- a/src/react/tests/useInfiniteQuery.test.tsx
+++ b/src/react/tests/useInfiniteQuery.test.tsx
@@ -206,7 +206,7 @@ describe('useInfiniteQuery', () => {
 
     await sleep(300)
 
-    expect(states.length).toBe(6)
+    expect(states.length).toBe(7)
     expect(states[0]).toMatchObject({
       data: undefined,
       isFetching: true,
@@ -243,7 +243,15 @@ describe('useInfiniteQuery', () => {
       isSuccess: true,
       isPreviousData: true,
     })
+    // Hook state update
     expect(states[5]).toMatchObject({
+      data: { pages: ['0-desc', '1-desc'] },
+      isFetching: true,
+      isFetchingNextPage: false,
+      isSuccess: true,
+      isPreviousData: true,
+    })
+    expect(states[6]).toMatchObject({
       data: { pages: ['0-asc'] },
       isFetching: false,
       isFetchingNextPage: false,
@@ -816,7 +824,7 @@ describe('useInfiniteQuery', () => {
 
     await sleep(100)
 
-    expect(states.length).toBe(5)
+    expect(states.length).toBe(6)
     expect(states[0]).toMatchObject({
       hasNextPage: undefined,
       data: undefined,
@@ -840,8 +848,16 @@ describe('useInfiniteQuery', () => {
       isFetchingNextPage: false,
       isSuccess: true,
     })
-    // Refetch
+    // Hook state update
     expect(states[3]).toMatchObject({
+      hasNextPage: true,
+      data: { pages: [7, 8] },
+      isFetching: false,
+      isFetchingNextPage: false,
+      isSuccess: true,
+    })
+    // Refetch
+    expect(states[4]).toMatchObject({
       hasNextPage: true,
       data: { pages: [7, 8] },
       isFetching: true,
@@ -849,7 +865,7 @@ describe('useInfiniteQuery', () => {
       isSuccess: true,
     })
     // Refetch done
-    expect(states[4]).toMatchObject({
+    expect(states[5]).toMatchObject({
       hasNextPage: true,
       data: { pages: [7, 8] },
       isFetching: false,

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { notifyManager } from '../core/notifyManager'
 import { QueryObserver } from '../core/queryObserver'
-import { QueryObserverResult } from '../core/types'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
 import { UseBaseQueryOptions } from './types'
@@ -59,23 +58,12 @@ export function useBaseQuery<TQueryFnData, TError, TData, TQueryData>(
   }
 
   const currentResult = observer.getCurrentResult()
-
-  // Remember latest result to prevent redundant renders
-  const latestResultRef = React.useRef(currentResult)
-  latestResultRef.current = currentResult
-
-  const [, rerender] = React.useState({})
+  const [, setCurrentResult] = React.useState(currentResult)
 
   // Subscribe to the observer
   React.useEffect(() => {
     errorResetBoundary.clearReset()
-    return observer.subscribe(
-      notifyManager.batchCalls((result: QueryObserverResult) => {
-        if (result !== latestResultRef.current) {
-          rerender({})
-        }
-      })
-    )
+    return observer.subscribe(notifyManager.batchCalls(setCurrentResult))
   }, [observer, errorResetBoundary])
 
   // Handle suspense


### PR DESCRIPTION
Reverts the render optimization from https://github.com/tannerlinsley/react-query/pull/1487 because it is not guaranteed React will actually commit the render when a hook is called (renders might be discarded). Added a test to cover this behavior.

Fixes https://github.com/tannerlinsley/react-query/issues/1535