### PR TITLE
docs: describe exceptional behavior of onSuccess of useMutation.mutate

### DIFF
--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -77,6 +77,7 @@ mutate(variables, {
     - Optional
     - The variables object to pass to the `mutationFn`.
   - Remaining options extend the same options described above in the `useMutation` hook.
+  - If you make multiple requests, `onSuccess` will fire only after the latest call you've made.
 - `mutateAsync: (variables: TVariables, { onSuccess, onSettled, onError }) => Promise<TData>`
   - Similar to `mutate` but returns a promise which can be awaited.
 - `status: string`


### PR DESCRIPTION
We've discussed in https://github.com/tannerlinsley/react-query/issues/241 and 

still same in `3.5.11` when you use `useMutation.mutate.onSuccess`, but `useMutation( , { onSuccess: ... })` doesn't.

I also made an example: https://codesandbox.io/s/sleepy-haze-s9p7z?file=/src/App.js

#1573