### PR TITLE
docs: fix typo in ssr guide

### DIFF
--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -131,7 +131,7 @@ import { dehydrate, Hydrate } from 'react-query/hydration'
 
 const queryClient = new QueryClient()
 await queryClient.prefetchQuery('key', fn)
-const dehydratedState = dehydrate(client)
+const dehydratedState = dehydrate(queryClient)
 
 const html = ReactDOM.renderToString(
   <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Fix typo in the [SSR guide](https://react-query.tanstack.com/guides/ssr#on-the-server)

![image](https://user-images.githubusercontent.com/395650/104156202-e9811100-53e8-11eb-88c6-ea813eb4c37d.png)

`client` does not exist (should be `queryClient`)