### PR TITLE
fix: stop returning cancelledError on reset during fetch

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -227,7 +227,7 @@ export class Query<
 
   destroy(): void {
     this.clearGcTimeout()
-    this.cancel()
+    this.cancel({ silent: true })
   }
 
   reset(): void {


### PR DESCRIPTION
Fixes #1594.

Tested manually by resetting a query using dev tools while it's refetching. 

Added a test to cover this behaviour.

(My first PR here – happy to make further changes if I've missed anything!)