### PR TITLE
docs: add v2 docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [React Tabl
 
 ## Visit [react-query.tanstack.com](https://react-query.tanstack.com) for docs, guides, API and more!
 
+Still on **React Query v2**? No problem! Check out the v2 docs here: https://react-query-v2.tanstack.com/.
 ## Quick Features
 
 - Transport/protocol/backend agnostic data fetching (REST, GraphQL, promises, whatever!)

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -24,9 +24,18 @@ export const Nav = () => (
         <div className="flex flex-grow items-center justify-between w-3/4 md:w-auto md:justify-end space-x-4 md:space-x-8 h-16">
           <div className="flex space-x-4 md:space-x-8 text-sm md:text-base">
             <div>
+              Docs (
               <Link href="/overview">
-                <a className="leading-6 font-medium">Docs</a>
-              </Link>
+                <a className="leading-6 font-medium">v3</a>
+              </Link>{' '}
+              /{' '}
+              <a
+                href="https://react-query-v2.tanstack.com/docs/overview"
+                className="leading-6 font-medium"
+              >
+                v2
+              </a>
+              )
             </div>
             <div>
               <Link href="/examples/simple">

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -24,18 +24,9 @@ export const Nav = () => (
         <div className="flex flex-grow items-center justify-between w-3/4 md:w-auto md:justify-end space-x-4 md:space-x-8 h-16">
           <div className="flex space-x-4 md:space-x-8 text-sm md:text-base">
             <div>
-              Docs (
               <Link href="/overview">
-                <a className="leading-6 font-medium">v3</a>
-              </Link>{' '}
-              /{' '}
-              <a
-                href="https://react-query-v2.tanstack.com/docs/overview"
-                className="leading-6 font-medium"
-              >
-                v2
-              </a>
-              )
+                <a className="leading-6 font-medium">Docs</a>
+              </Link>
             </div>
             <div>
               <Link href="/examples/simple">

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -85,6 +85,17 @@ const Home = ({ sponsors }) => {
                       </a>
                     </div>
                   </div>
+                  <div className="mt-5">
+                    <p>
+                      Still using v2? No problem!{' '}
+                      <a
+                        href="https://react-query-v2.tanstack.com/docs/overview"
+                        className="text-blue-600 font-semibold transition-colors duration-150 ease-out"
+                      >
+                        Find the v2 docs here.
+                      </a>
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Since folks are still on v2 and asking about those docs this adds a couple front-facing spots to find them: 

1. main repo README
2. main RQ docs nav

<img width="506" alt="Screen Shot 2021-01-21 at 2 37 19 PM" src="https://user-images.githubusercontent.com/14936212/105404681-3e4a3600-5bf8-11eb-8a6c-3fe2da70a5fc.png">
