### PR TITLE
chore(examples): update axios version in examples folder

### DIFF
--- a/examples/auto-refetching/package.json
+++ b/examples/auto-refetching/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.2",
     "react": "16.13.0",

--- a/examples/basic-graphql-request/package.json
+++ b/examples/basic-graphql-request/package.json
@@ -7,7 +7,7 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "graphql": "^15.3.0",
     "graphql-request": "^3.1.0",
     "react": "^16.8.6",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,7 +7,7 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-query": "^3.5.0",

--- a/examples/custom-hooks/package.json
+++ b/examples/custom-hooks/package.json
@@ -7,7 +7,7 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-query": "^3.5.0",

--- a/examples/default-query-function/package.json
+++ b/examples/default-query-function/package.json
@@ -7,7 +7,7 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-query": "^3.5.0",

--- a/examples/focus-refetching/package.json
+++ b/examples/focus-refetching/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.2",
     "react": "16.13.0",

--- a/examples/load-more-infinite-scroll/package.json
+++ b/examples/load-more-infinite-scroll/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.2",
     "react": "16.13.0",

--- a/examples/optimistic-updates-typescript/package.json
+++ b/examples/optimistic-updates-typescript/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/react": "^17.0.0",
     "@types/node": "14.14.14",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.2.2",
     "react": "^17.0.1",

--- a/examples/optimistic-updates/package.json
+++ b/examples/optimistic-updates/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.2.2",
     "react": "16.13.0",

--- a/examples/pagination/package.json
+++ b/examples/pagination/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.2",
     "react": "16.13.0",

--- a/examples/prefetching/package.json
+++ b/examples/prefetching/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.2",
     "react": "16.13.0",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -7,7 +7,7 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-query": "^3.5.0",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.9.7",
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-query": "^3.5.0",

--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "main": "src/index.js",
   "dependencies": {
-    "axios": "0.19.2",
+    "axios": "^0.21.1",
     "react": "0.0.0-experimental-5faf377df",
     "react-dom": "0.0.0-experimental-5faf377df",
     "react-error-boundary": "^2.2.3",


### PR DESCRIPTION
To get rid of nasty npm warning when running examples. 

```bash
npm WARN deprecated axios@0.19.2: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
```