### PR TITLE
fix(queryObserver): Load currentResult for placeholder data after first update

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -406,10 +406,18 @@ export class QueryObserver<
       typeof data === 'undefined' &&
       status === 'loading'
     ) {
-      const placeholderData =
+      let placeholderData : TData | undefined;
+
+      // Use the previous result data if exists instead of readding placeholder data
+      if(this.currentResult && typeof this.currentResult.data !== 'undefined') {
+        placeholderData = this.currentResult.data
+      } else {
+        placeholderData =
         typeof this.options.placeholderData === 'function'
           ? (this.options.placeholderData as PlaceholderDataFunction<TData>)()
           : this.options.placeholderData
+      }
+
       if (typeof placeholderData !== 'undefined') {
         status = 'success'
         data = placeholderData

--- a/src/core/tests/queryObserver.test.tsx
+++ b/src/core/tests/queryObserver.test.tsx
@@ -329,4 +329,29 @@ describe('queryObserver', () => {
     expect(results[0].data).toBe('data')
     unsubscribe()
   })
+
+  test('should only call placeholder data once for relevant data', async () => {
+    const key = queryKey()
+    const placeholderData = jest.fn(() => 'placeholder');
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => 'data',
+      placeholderData,
+    })
+
+    expect(observer.getCurrentResult()).toMatchObject({
+      status: 'success',
+      data: 'placeholder',
+    })
+
+    const results: QueryObserverResult<unknown>[] = []
+
+    const unsubscribe = observer.subscribe(x => {
+      results.push(x)
+    })
+
+    await sleep(10)
+    expect(placeholderData).toBeCalledTimes(1)
+    unsubscribe()
+  })
 })


### PR DESCRIPTION
Only the `this.currentQuery` data is checked for stored data when updating results, where placeholder data is stored only in `this.currentResult` on update. So if we hit the placeholder conditional, we check to see if there is data already in the `currentResult` before running the placeholder fn.

It could be argued that this logic could be pulled out of the placeholder conditional, since if any other flow ever does this, it would also need this data, but unsure of the effect of this change.

Fixes #1522 