### PR TITLE
refactor react-query core react integration to observer hooks

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,9 +9,11 @@ export {
 } from './QueryErrorResetBoundary'
 export { useIsFetching } from './useIsFetching'
 export { useMutation } from './useMutation'
+export { useMutationObserver } from './useMutationObserver'
 export { useQuery } from './useQuery'
-export { useQueries } from './useQueries'
+export { useQueries, useQueriesObserver } from './useQueries'
 export { useInfiniteQuery } from './useInfiniteQuery'
+export { useQueryObserver } from './useQueryObserver'
 
 // Types
 export * from './types'

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -8,7 +8,7 @@ import {
   QueryObserverResult,
 } from '../core/types'
 
-export interface UseBaseQueryOptions<
+export interface UseQueryObserverOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
@@ -19,7 +19,7 @@ export interface UseQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData
-> extends UseBaseQueryOptions<TQueryFnData, TError, TData> {}
+> extends UseQueryObserverOptions<TQueryFnData, TError, TData> {}
 
 export interface UseInfiniteQueryOptions<
   TQueryFnData = unknown,
@@ -34,7 +34,7 @@ export interface UseInfiniteQueryOptions<
     TQueryData
   > {}
 
-export type UseBaseQueryResult<
+export type UseQueryObserverResult<
   TData = unknown,
   TError = unknown
 > = QueryObserverResult<TData, TError>
@@ -42,7 +42,7 @@ export type UseBaseQueryResult<
 export type UseQueryResult<
   TData = unknown,
   TError = unknown
-> = UseBaseQueryResult<TData, TError>
+> = UseQueryObserverResult<TData, TError>
 
 export type UseInfiniteQueryResult<
   TData = unknown,

--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -3,7 +3,7 @@ import { InfiniteQueryObserver } from '../core/infiniteQueryObserver'
 import { QueryFunction, QueryKey } from '../core/types'
 import { parseQueryArgs } from '../core/utils'
 import { UseInfiniteQueryOptions, UseInfiniteQueryResult } from './types'
-import { useBaseQuery } from './useBaseQuery'
+import { useQueryObserver } from './useQueryObserver'
 
 // HOOK
 
@@ -39,7 +39,7 @@ export function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnData>(
   arg3?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
 ): UseInfiniteQueryResult<TData, TError> {
   const options = parseQueryArgs(arg1, arg2, arg3)
-  return useBaseQuery(
+  return useQueryObserver(
     options,
     InfiniteQueryObserver as typeof QueryObserver
   ) as UseInfiniteQueryResult<TData, TError>

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -1,19 +1,15 @@
-import React from 'react'
 
-import { notifyManager } from '../core/notifyManager'
-import { noop, parseMutationArgs } from '../core/utils'
+import { parseMutationArgs } from '../core/utils'
 import { MutationObserver } from '../core/mutationObserver'
-import { useQueryClient } from './QueryClientProvider'
 import {
-  UseMutateFunction,
   UseMutationOptions,
   UseMutationResult,
 } from './types'
 import {
   MutationFunction,
   MutationKey,
-  MutationObserverResult,
 } from '../core/types'
+import { useMutationObserver } from './useMutationObserver'
 
 // HOOK
 
@@ -69,55 +65,7 @@ export function useMutation<
   arg3?: UseMutationOptions<TData, TError, TVariables, TContext>
 ): UseMutationResult<TData, TError, TVariables, TContext> {
   const options = parseMutationArgs(arg1, arg2, arg3)
-  const queryClient = useQueryClient()
-
-  // Create mutation observer
-  const observerRef = React.useRef<
-    MutationObserver<TData, TError, TVariables, TContext>
-  >()
-  const observer =
-    observerRef.current || new MutationObserver(queryClient, options)
-  observerRef.current = observer
-
-  // Update options
-  if (observer.hasListeners()) {
-    observer.setOptions(options)
-  }
-
-  const [currentResult, setCurrentResult] = React.useState(() =>
-    observer.getCurrentResult()
-  )
-
-  // Subscribe to the observer
-  React.useEffect(
-    () =>
-      observer.subscribe(
-        notifyManager.batchCalls(
-          (
-            result: MutationObserverResult<TData, TError, TVariables, TContext>
-          ) => {
-            // Check if the component is still mounted
-            if (observer.hasListeners()) {
-              setCurrentResult(result)
-            }
-          }
-        )
-      ),
-    [observer]
-  )
-
-  const mutate = React.useCallback<
-    UseMutateFunction<TData, TError, TVariables, TContext>
-  >(
-    (variables, mutateOptions) => {
-      observer.mutate(variables, mutateOptions).catch(noop)
-    },
-    [observer]
-  )
-
-  if (currentResult.error && observer.options.useErrorBoundary) {
-    throw currentResult.error
-  }
-
-  return { ...currentResult, mutate, mutateAsync: currentResult.mutate }
+  return useMutationObserver(options, MutationObserver)
 }
+
+

--- a/src/react/useMutationObserver.ts
+++ b/src/react/useMutationObserver.ts
@@ -1,0 +1,65 @@
+import React from 'react'
+import { notifyManager } from '../core/notifyManager'
+import { noop } from '../core/utils'
+import { MutationObserver } from '../core/mutationObserver'
+import { useQueryClient } from './QueryClientProvider'
+import { UseMutateFunction } from './types'
+import { MutationObserverOptions, MutationObserverResult } from '../core/types'
+
+export function useMutationObserver<TData, TError, TVariables, TContext>(
+  options: MutationObserverOptions<TData, TError, TVariables, TContext>,
+  Observer: typeof MutationObserver
+) {
+  const queryClient = useQueryClient()
+
+  // Create mutation observer
+  const observerRef = React.useRef<
+    MutationObserver<TData, TError, TVariables, TContext>
+  >()
+  const observer =
+    observerRef.current ||
+    new Observer<TData, TError, TVariables, TContext>(queryClient, options)
+  observerRef.current = observer
+
+  // Update options
+  if (observer.hasListeners()) {
+    observer.setOptions(options)
+  }
+
+  const [currentResult, setCurrentResult] = React.useState(() =>
+    observer.getCurrentResult()
+  )
+
+  // Subscribe to the observer
+  React.useEffect(
+    () =>
+      observer.subscribe(
+        notifyManager.batchCalls(
+          (
+            result: MutationObserverResult<TData, TError, TVariables, TContext>
+          ) => {
+            // Check if the component is still mounted
+            if (observer.hasListeners()) {
+              setCurrentResult(result)
+            }
+          }
+        )
+      ),
+    [observer]
+  )
+
+  const mutate = React.useCallback<
+    UseMutateFunction<TData, TError, TVariables, TContext>
+  >(
+    (variables, mutateOptions) => {
+      observer.mutate(variables, mutateOptions).catch(noop)
+    },
+    [observer]
+  )
+
+  if (currentResult.error && observer.options.useErrorBoundary) {
+    throw currentResult.error
+  }
+
+  return { ...currentResult, mutate, mutateAsync: currentResult.mutate }
+}

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -1,17 +1,28 @@
 import React from 'react'
+import { QueryObserver } from '../core'
 
 import { notifyManager } from '../core/notifyManager'
 import { QueriesObserver } from '../core/queriesObserver'
 import { useQueryClient } from './QueryClientProvider'
 import { UseQueryOptions, UseQueryResult } from './types'
 
-export function useQueries(queries: UseQueryOptions[]): UseQueryResult[] {
+export function useQueries<TData, TError>(
+  queries: UseQueryOptions<TData, TError>[]
+): UseQueryResult<TData, TError>[] {
+  return useQueriesObserver(queries, QueryObserver)
+}
+
+export function useQueriesObserver<TData = unknown, TError = unknown>(
+  queries: UseQueryOptions<TData, TError>[],
+  Observer: typeof QueryObserver
+): UseQueryResult<TData, TError>[] {
   const queryClient = useQueryClient()
 
   // Create queries observer
-  const observerRef = React.useRef<QueriesObserver>()
+  const observerRef = React.useRef<QueriesObserver<TData, TError>>()
   const observer =
-    observerRef.current || new QueriesObserver(queryClient, queries)
+    observerRef.current ||
+    new QueriesObserver<TData, TError>(queryClient, queries, Observer)
   observerRef.current = observer
 
   // Update queries

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -2,7 +2,7 @@ import { QueryObserver } from '../core'
 import { QueryFunction, QueryKey } from '../core/types'
 import { parseQueryArgs } from '../core/utils'
 import { UseQueryOptions, UseQueryResult } from './types'
-import { useBaseQuery } from './useBaseQuery'
+import { useQueryObserver } from './useQueryObserver'
 
 // HOOK
 
@@ -38,5 +38,5 @@ export function useQuery<TQueryFnData, TError, TData = TQueryFnData>(
   arg3?: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError> {
   const parsedOptions = parseQueryArgs(arg1, arg2, arg3)
-  return useBaseQuery(parsedOptions, QueryObserver)
+  return useQueryObserver(parsedOptions, QueryObserver)
 }

--- a/src/react/useQueryObserver.ts
+++ b/src/react/useQueryObserver.ts
@@ -2,15 +2,19 @@ import React from 'react'
 
 import { notifyManager } from '../core/notifyManager'
 import { QueryObserver } from '../core/queryObserver'
-import { QueryObserverResult } from '../core/types'
+import { QueryObserverOptions, QueryObserverResult } from '../core/types'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
-import { UseBaseQueryOptions } from './types'
 
-export function useBaseQuery<TQueryFnData, TError, TData, TQueryData>(
-  options: UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryData>,
+export function useQueryObserver<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData
+>(
+  options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>,
   Observer: typeof QueryObserver
-) {
+): QueryObserverResult<TData, TError> {
   const queryClient = useQueryClient()
   const errorResetBoundary = useQueryErrorResetBoundary()
   const defaultedOptions = queryClient.defaultQueryObserverOptions(options)


### PR DESCRIPTION
Refactor the integration between the core and react-query to use `useQueryObserver` instead of `useBaseQuery` and add `useMutationObserver` and `useQueriesObserver` hooks. These hooks allow the consumer to pass a custom QueryObserver/MutationObserver/etc to customize these hooks where you want to synchronize the data from another external source outside of the react lifecycle.

The purpose was to allow overriden QueryObserver classes to be passed as the