### PR TITLE
docs: fixes fetch example which throws error

### DIFF
--- a/docs/src/pages/guides/query-functions.md
+++ b/docs/src/pages/guides/query-functions.md
@@ -36,11 +36,11 @@ While most utilities like `axios` or `graphql-request` automatically throw error
 
 ```js
 useQuery(['todos', todoId], async () => {
-  const { ok, json } = await fetch('/todos/' + todoId)
-  if (!ok) {
+  const response = await fetch('/todos/' + todoId)
+  if (!response.ok) {
     throw new Error('Network response was not ok')
   }
-  return json()
+  return response
 })
 ```
 

--- a/docs/src/pages/guides/query-functions.md
+++ b/docs/src/pages/guides/query-functions.md
@@ -40,7 +40,7 @@ useQuery(['todos', todoId], async () => {
   if (!response.ok) {
     throw new Error('Network response was not ok')
   }
-  return response
+  return response.json()
 })
 ```
 


### PR DESCRIPTION
I tried to run the example in a React Native project and it gave me the following error:

`Error: Objects are not valid as a React child (found: TypeError: Cannot read property 'text' of undefined). If you meant to render a collection of children, use an array instead.`

I guess the `useQuery` hook tries to access the text property of the response which is not available when returning `json()`.