### PR TITLE
fix: respect the enabled flag

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -666,8 +666,8 @@ function shouldFetchOptionally(
   prevOptions: QueryObserverOptions<any, any>
 ): boolean {
   return (
-    (query !== prevQuery ||
-      (options.enabled !== false && prevOptions.enabled === false)) &&
+    (options.enabled !== false && 
+      (query !== prevQuery || prevOptions.enabled === false)) &&
     isStale(query, options)
   )
 }


### PR DESCRIPTION
The 3.9 update seems to have broken the `enabled` logic in certain circumstances. I think this fixes it (I tested in my app locally).