### PR TITLE
refactor(QueryClientProvider): validation for context being overwritten

### DIFF
--- a/src/react/QueryClientProvider.tsx
+++ b/src/react/QueryClientProvider.tsx
@@ -6,6 +6,10 @@ const QueryClientContext = (() => {
   const context = React.createContext<QueryClient | undefined>(undefined)
   if (typeof window !== 'undefined') {
     // @ts-ignore
+    if (typeof window.ReactQueryClientContext !== 'undefined') {
+      throw new Error('ReactQueryClientContext is already set, you should only set this once')
+    }
+    // @ts-ignore
     window.ReactQueryClientContext = context
   }
   return context


### PR DESCRIPTION
I had an issue within our application which basically meant we were overwriting our `ReactQueryClientContext` with the default because of some unexpected rerendering. This meant even having set `<QueryClientProvider>` at basically root we were still getting the error `No Query set...` error. I think it would be great to supply a correct error message in this scenario as I'm sure I won't be the only one to come across this in the future.

First time contributing here, let me know if I need to change anything :)