### PR TITLE
docs(next-example): correct typo (SSR -> SSG)

### DIFF
--- a/docs/src/pages/examples/nextjs.mdx
+++ b/docs/src/pages/examples/nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 id: nextjs
-title: Nextjs SSR
+title: Nextjs SSG
 toc: false
 ---
 


### PR DESCRIPTION
Correct typo in the title.