### PR TITLE
Prefer ReadonlyArray for query keys

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,7 @@ import type { QueryBehavior } from './query'
 import type { RetryValue, RetryDelayValue } from './retryer'
 import type { QueryFilters } from './utils'
 
-export type QueryKey = string | ReadonlyArray<unknown>
+export type QueryKey = string | readonly unknown[]
 
 export type QueryFunction<T = unknown> = (
   context: QueryFunctionContext<any>
@@ -448,7 +448,7 @@ export type InfiniteQueryObserverResult<TData = unknown, TError = unknown> =
   | InfiniteQueryObserverRefetchErrorResult<TData, TError>
   | InfiniteQueryObserverSuccessResult<TData, TError>
 
-export type MutationKey = string | ReadonlyArray<unknown>
+export type MutationKey = string | readonly unknown[]
 
 export type MutationStatus = 'idle' | 'loading' | 'success' | 'error'
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,7 @@ import type { QueryBehavior } from './query'
 import type { RetryValue, RetryDelayValue } from './retryer'
 import type { QueryFilters } from './utils'
 
-export type QueryKey = string | unknown[]
+export type QueryKey = string | ReadonlyArray<unknown>
 
 export type QueryFunction<T = unknown> = (
   context: QueryFunctionContext<any>
@@ -448,7 +448,7 @@ export type InfiniteQueryObserverResult<TData = unknown, TError = unknown> =
   | InfiniteQueryObserverRefetchErrorResult<TData, TError>
   | InfiniteQueryObserverSuccessResult<TData, TError>
 
-export type MutationKey = string | unknown[]
+export type MutationKey = string | ReadonlyArray<unknown>
 
 export type MutationStatus = 'idle' | 'loading' | 'success' | 'error'
 
@@ -463,7 +463,7 @@ export interface MutationOptions<
   TContext = unknown
 > {
   mutationFn?: MutationFunction<TData, TVariables>
-  mutationKey?: string | unknown[]
+  mutationKey?: MutationKey
   variables?: TVariables
   onMutate?: (variables: TVariables) => Promise<TContext> | TContext
   onSuccess?: (

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -223,8 +223,8 @@ export function stableValueHash(value: any): string {
  * Checks if key `b` partially matches with key `a`.
  */
 export function partialMatchKey(
-  a: string | unknown[],
-  b: string | unknown[]
+  a: QueryKey,
+  b: QueryKey
 ): boolean {
   return partialDeepEqual(ensureArray(a), ensureArray(b))
 }


### PR DESCRIPTION
Mutable arrays can be passed to functions expecting readonly arrays but readonly arrays can't be passed to functions expecting mutable arrays. Since `react-query` doesn't actually mutate query keys, it should use the more permissive `ReadonlyArray` for `QueryKey` (and `MutationKey`) instead.

This allows users to do things like this without having to strip `readonly` from the inferred types:

```
const query = [["my.query.key", "abc"], () => fetch("/my/resource")] as const
```