### PR TITLE
docs (initial-query-data): Add missing period

### DIFF
--- a/docs/src/pages/guides/initial-query-data.md
+++ b/docs/src/pages/guides/initial-query-data.md
@@ -99,7 +99,7 @@ function Todo({ todoId }) {
 
 ### Initial Data from the cache with `initialDataUpdatedAt`
 
-Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData` Instead of using an artificial `staleTime` to keep your query from refetching immediately, it's suggested that you pass the source query's `dataUpdatedAt` to `initialDataUpdatedAt`. This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
+Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData`. Instead of using an artificial `staleTime` to keep your query from refetching immediately, it's suggested that you pass the source query's `dataUpdatedAt` to `initialDataUpdatedAt`. This provides the query instance with all the information it needs to determine if and when the query needs to be refetched, regardless of initial data being provided.
 
 ```js
 function Todo({ todoId }) {


### PR DESCRIPTION
https://react-query.tanstack.com/guides/initial-query-data#initial-data-from-the-cache-with-initialdataupdatedat

```
- Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData`
+ Getting initial data from the cache means the source query you're using to look up the initial data from is likely old, but `initialData`.
```