### PR TITLE
Add throwOnError to prefetchQuery()

### DIFF
--- a/docs/src/pages/guides/prefetching.md
+++ b/docs/src/pages/guides/prefetching.md
@@ -14,6 +14,7 @@ const prefetchTodos = async () => {
 
 - If data for this query is already in the cache and **not invalidated**, the data will not be fetched
 - If a `staleTime` is passed eg. `prefetchQuery('todos', fn, { staleTime: 5000 })` and the data is older than the specified staleTime, the query will be fetched
+- If `throwOnError` is set to true, function will throw an error if the query function fails.
 - If no instances of `useQuery` appear for a prefetched query, it will be deleted and garbage collected after the time specified in `cacheTime`.
 
 ## Manually Priming a Query

--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -131,7 +131,9 @@ await queryClient.prefetchQuery(queryKey)
 
 **Options**
 
-The options for `prefetchQuery` are exactly the same as those of [`fetchQuery`](#queryclientfetchquery).
+The options for `prefetchQuery` are similar as those of [`fetchQuery`](#queryclientfetchquery).
+
+Additionally `prefetchQuery` does not act on an error thrown in the `queryFn`. Set `throwOnError` to `true` in the options to throw an error when one happens in the `queryFn`.
 
 **Returns**
 

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -18,6 +18,7 @@ import type {
   MutationKey,
   MutationObserverOptions,
   MutationOptions,
+  PrefetchQueryOptions,
   QueryFunction,
   QueryKey,
   QueryObserverOptions,
@@ -281,21 +282,34 @@ export class QueryClient {
       : Promise.resolve(query.state.data as TData)
   }
 
-  prefetchQuery(options: FetchQueryOptions): Promise<void>
-  prefetchQuery(queryKey: QueryKey, options?: FetchQueryOptions): Promise<void>
+  prefetchQuery(options: PrefetchQueryOptions): Promise<void>
+  prefetchQuery(
+    queryKey: QueryKey,
+    options?: PrefetchQueryOptions
+  ): Promise<void>
   prefetchQuery(
     queryKey: QueryKey,
     queryFn: QueryFunction,
-    options?: FetchQueryOptions
+    options?: PrefetchQueryOptions
   ): Promise<void>
   prefetchQuery(
-    arg1: QueryKey | FetchQueryOptions,
-    arg2?: QueryFunction | FetchQueryOptions,
-    arg3?: FetchQueryOptions
+    arg1: QueryKey | PrefetchQueryOptions,
+    arg2?: QueryFunction | PrefetchQueryOptions,
+    arg3?: PrefetchQueryOptions
   ): Promise<void> {
     return this.fetchQuery(arg1 as any, arg2 as any, arg3)
       .then(noop)
-      .catch(noop)
+      .catch(err => {
+        if (
+          (arg1 as PrefetchQueryOptions).throwOnError ||
+          (arg2 && (arg2 as PrefetchQueryOptions).throwOnError) ||
+          (arg3 && arg3.throwOnError)
+        ) {
+          return err
+        }
+
+        return noop()
+      })
   }
 
   fetchInfiniteQuery<

--- a/src/core/tests/queryClient.test.tsx
+++ b/src/core/tests/queryClient.test.tsx
@@ -338,6 +338,25 @@ describe('queryClient', () => {
 
       consoleMock.mockRestore()
     })
+
+    test('should throw error when throwOnError is set to true', async () => {
+      const key = queryKey()
+
+      try {
+        await queryClient.prefetchQuery(
+          key,
+          async () => {
+            throw new Error('error')
+          },
+          {
+            retry: false,
+            throwOnError: true
+          }
+        )
+      } catch (err) {
+        expect(err).toBeDefined();
+      }
+    })
   })
 
   describe('removeQueries', () => {
@@ -373,7 +392,7 @@ describe('queryClient', () => {
         await queryClient.fetchQuery(key2, async () => {
           return Promise.reject('err')
         })
-      } catch {}
+      } catch { }
       queryClient.fetchQuery(key1, async () => {
         await sleep(1000)
         return 'data2'
@@ -383,7 +402,7 @@ describe('queryClient', () => {
           await sleep(1000)
           return Promise.reject('err2')
         })
-      } catch {}
+      } catch { }
       queryClient.fetchQuery(key3, async () => {
         await sleep(1000)
         return 'data3'

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -212,6 +212,14 @@ export interface FetchQueryOptions<
   staleTime?: number
 }
 
+export interface PrefetchQueryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData
+> extends FetchQueryOptions<TQueryFnData, TError, TData> {
+  throwOnError?: boolean
+}
+
 export interface FetchInfiniteQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,


### PR DESCRIPTION
## Description

This PR adds a `throwOnError` option to `prefetchQuery()`. With this new option, devs can opt to have `prefetchQuery()` throw an error when one happens inside the `queryFn`.

Example:

```ts
try {
  await queryClient.prefetchQuery('test', () => throwError(), { throwOnError: true })
} catch (err) {
  console.error('error happened', err);
}
```