### PR TITLE
fix: Do not refetch active queries if "refetchActive" is set to "false"

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -207,7 +207,7 @@ export class QueryClient {
     const refetchFilters: QueryFilters = {
       ...filters,
       active: filters.refetchActive ?? true,
-      inactive: filters.refetchInactive ?? false,
+      inactive: filters.refetchInactive,
     }
 
     return notifyManager.batch(() => {

--- a/src/core/tests/queryClient.test.tsx
+++ b/src/core/tests/queryClient.test.tsx
@@ -550,6 +550,22 @@ describe('queryClient', () => {
       expect(queryFn1).toHaveBeenCalledTimes(1)
       expect(queryFn2).toHaveBeenCalledTimes(1)
     })
+
+    test('should not refetch active queries when "refetchActive" is false', async () => {
+      const key1 = queryKey()
+      const queryFn1 = jest.fn()
+      await queryClient.fetchQuery(key1, queryFn1)
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key1,
+        staleTime: Infinity,
+      })
+      const unsubscribe = observer.subscribe()
+      queryClient.invalidateQueries(key1, {
+        refetchActive: false,
+      })
+      unsubscribe()
+      expect(queryFn1).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('resetQueries', () => {


### PR DESCRIPTION
This PR fixes the issue reported here: https://github.com/tannerlinsley/react-query/issues/1931

When a query was invalidated and `refetchActive` was set to `false`, the query would still be refetched, unless `refetchInactive` was set to `true`. 

The PR fixes this by not letting the `inactive` option in the query filters default to `false` if it was actually `undefined`.