### PR TITLE
fix(query): the page parameter at infiniteQuery when using fetchNextPage

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -365,7 +365,7 @@ export class Query<
     const queryKey = ensureArray(this.queryKey)
     const queryFnContext: QueryFunctionContext = {
       queryKey,
-      pageParam: undefined,
+      pageParam: fetchOptions?.meta?.pageParam,
     }
 
     // Create fetch function


### PR DESCRIPTION
This PR fixes the issue reported here: https://github.com/tannerlinsley/react-query/discussions/1928

Resolves the page parameter value being `undefined`.