### PR TITLE
fix(useQuery): let context infer queryKey

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,9 +5,10 @@ import type { QueryFilters } from './utils'
 
 export type QueryKey = string | readonly unknown[]
 
-export type QueryFunction<T = unknown> = (
-  context: QueryFunctionContext<any>
-) => T | Promise<T>
+export type QueryFunction<
+  T = unknown,
+  TQueryKey extends QueryKey = QueryKey
+> = (context: QueryFunctionContext<TQueryKey>) => T | Promise<T>
 
 export interface QueryFunctionContext<
   TQueryKey extends QueryKey = QueryKey,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -4,6 +4,8 @@ import {
   InfiniteQueryObserverResult,
   MutateOptions,
   MutationStatus,
+  QueryFunction,
+  QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
 } from '../core/types'
@@ -18,8 +20,16 @@ export interface UseBaseQueryOptions<
 export interface UseQueryOptions<
   TQueryFnData = unknown,
   TError = unknown,
-  TData = TQueryFnData
-> extends UseBaseQueryOptions<TQueryFnData, TError, TData> {}
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>
+  extends Omit<
+    UseBaseQueryOptions<TQueryFnData, TError, TData>,
+    'queryFn' | 'queryKey'
+  > {
+  queryKey?: TQueryKey
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey>
+}
 
 export interface UseInfiniteQueryOptions<
   TQueryFnData = unknown,

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -16,18 +16,20 @@ export function useQuery<
 export function useQuery<
   TQueryFnData = unknown,
   TError = unknown,
-  TData = TQueryFnData
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
-  options?: UseQueryOptions<TQueryFnData, TError, TData>
+  queryKey: TQueryKey,
+  options?: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
 ): UseQueryResult<TData, TError>
 export function useQuery<
   TQueryFnData = unknown,
   TError = unknown,
-  TData = TQueryFnData
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 >(
-  queryKey: QueryKey,
-  queryFn: QueryFunction<TQueryFnData>,
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, TQueryKey>,
   options?: UseQueryOptions<TQueryFnData, TError, TData>
 ): UseQueryResult<TData, TError>
 export function useQuery<TQueryFnData, TError, TData = TQueryFnData>(


### PR DESCRIPTION
Allows for the queryKey in the queryFn to be inferred as discussed in  #1462 

For example
![image](https://user-images.githubusercontent.com/2290276/110944936-68d58700-833d-11eb-9c13-126c8e717608.png)
