### PR TITLE
adds onQuery option which is called everytime before a fetch happens

### DIFF
--- a/docs/src/pages/reference/useInfiniteQuery.md
+++ b/docs/src/pages/reference/useInfiniteQuery.md
@@ -31,6 +31,13 @@ The options for `useInfiniteQuery` are identical to the [`useQuery` hook](/refer
     - `pageParam: unknown | undefined`
   - Must return a promise that will either resolves data or throws an error.
   - Make sure you return the data *and* the `pageParam` if needed for use in the props below.
+- `onFetch: (context: QueryFunctionContext) => void`
+  - Optional
+  - This function will fire will any time right before the query tries to fetch new data.
+  - Receives a `QueryFunctionContext` object with the following variables:
+    - `queryKey: QueryKey`
+    - `pageParam: unknown | undefined`
+  - Please note: `onFetch` is called for every retry. With default `retry: 3`, this function is called 4 times before `useInfiniteQuery()` reaches an error state.
 - `getNextPageParam: (lastPage, allPages) => unknown | undefined`
   - When new data is received for this query, this function receives both the last page of the infinite list of data and the full array of all pages.
   - It should return a **single variable** that will be passed as the last optional parameter to your query function.

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -34,6 +34,7 @@ const {
   keepPreviousData,
   notifyOnChangeProps,
   notifyOnChangePropsExclusions,
+  onFetch,
   onError,
   onSettled,
   onSuccess,
@@ -127,6 +128,12 @@ const result = useQuery({
   - Optional
   - If set, the component will not re-render if any of the listed properties change.
   - If set to `['isStale']` for example, the component will not re-render when the `isStale` property changes.
+- `onFetch: (context: QueryFunctionContext) => void`
+  - Optional
+  - This function will fire will any time right before the query tries to fetch new data.
+  - Receives a `QueryFunctionContext` object with the following variables:
+    - `queryKey: QueryKey`
+  - Please note: `onFetch` is called for every retry. With default `retry: 3`, this function is called 4 times before `useQuery()` reaches an error state.
 - `onSuccess: (data: TData) => void`
   - Optional
   - This function will fire any time the query successfully fetches new data.

--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -43,6 +43,7 @@ export function infiniteQueryBehavior<
             pageParam: param,
           }
 
+          context.preFetchFn(queryFnContext)
           const queryFnResult = queryFn(queryFnContext)
 
           const promise = Promise.resolve(queryFnResult).then(page => {

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -586,6 +586,11 @@ export class QueryObserver<
   onQueryUpdate(action: Action<TData, TError>): void {
     const notifyOptions: NotifyOptions = {}
 
+    if (action.type === 'preFetch') {
+      this.options.onFetch?.(action.context)
+      return
+    }
+
     if (action.type === 'success') {
       notifyOptions.onSuccess = true
     } else if (action.type === 'error') {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -144,6 +144,11 @@ export interface QueryObserverOptions<
    */
   notifyOnChangePropsExclusions?: Array<keyof InfiniteQueryObserverResult>
   /**
+   * This callback will fire right before the query will start fetching new data.
+   * Useful for side-effects that are specific to this query.
+   */
+  onFetch?: (context:QueryFunctionContext) => void
+  /**
    * This callback will fire any time the query successfully fetches new data.
    */
   onSuccess?: (data: TData) => void

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -39,6 +39,12 @@ export function useBaseQuery<TQueryFnData, TError, TData, TQueryData>(
     )
   }
 
+  if (defaultedOptions.onFetch) {
+    defaultedOptions.onFetch = notifyManager.batchCalls(
+      defaultedOptions.onFetch
+    )
+  }
+
   if (defaultedOptions.suspense) {
     // Always set stale time when using suspense to prevent
     // fetching again when directly mounting after suspending


### PR DESCRIPTION
### Description

This PR adds an `onQuery` option to `useQuery()`. 
Devs can opt to add a callback to handle side-effects related to the query in a similar fashion as `useMutation()` `onMutate`.

Example:
```tsx
const result = useQuery(
   queryKey,
  () => 'data',
  { onQuery: () => console.log('onQuery') }
)
```

Also:
Great job on react-query! Love using it :-)