### PR TITLE
docs(useInfiniteQuery): Correction of two mistakes in the code sample

### DIFF
--- a/docs/src/pages/guides/infinite-queries.md
+++ b/docs/src/pages/guides/infinite-queries.md
@@ -160,8 +160,8 @@ Manually removing a single value from an individual page:
 ```js
 const newPagesArray = []
 oldPagesArray?.pages.forEach(page => {
-  const newData = page.data.filter(val => val.id !== updatedId)
-  newPagesArray.push({ data: newData, pageParam: page.pageParam })
+  const newData = page.filter(val => val.id !== updatedId)
+  newPagesArray.push(newData)
 })
 queryClient.setQueryData('projects', data => ({
   pages: newPagesArray,


### PR DESCRIPTION
This code sample has two problems:
"oldPagesArray?.pages" only contains an array of different page arrays, so we should not write "page.data" to filter because "page.data" is undefined and we should write "page" instead.

Another mistake is the value pushed to the "newPagesArray" and the following value must be replaced: "newData"