### PR TITLE
fix(useQuery): type of initialData now corresponds to the type returned by the query-fn

### DIFF
--- a/src/core/infiniteQueryObserver.ts
+++ b/src/core/infiniteQueryObserver.ts
@@ -71,7 +71,7 @@ export class InfiniteQueryObserver<
   ): void {
     super.setOptions({
       ...options,
-      behavior: infiniteQueryBehavior<TQueryFnData, TError, TData>(),
+      behavior: infiniteQueryBehavior(),
     })
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -90,7 +90,7 @@ export interface QueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryOptions<TQueryFnData, TError, TData, TQueryKey> {
+> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.


### PR DESCRIPTION
fixes #2060 