### PR TITLE
docs(QueryStatus): change from enum to union type

### DIFF
--- a/docs/src/components/markdown.module.css
+++ b/docs/src/components/markdown.module.css
@@ -156,7 +156,9 @@
   @apply text-xl;
 }
 
-.markdown > h2 > a, .markdown > h3 > a {
+.markdown > h2 > a,
+.markdown > h3 > a,
+.markdown > h4 > a {
   @apply underline;
 }
 

--- a/docs/src/components/markdown.module.css
+++ b/docs/src/components/markdown.module.css
@@ -156,6 +156,10 @@
   @apply text-xl;
 }
 
+.markdown > h2 > a, .markdown > h3 > a {
+  @apply underline;
+}
+
 .markdown > .markdown ul {
   @apply list-disc;
 }

--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -116,6 +116,46 @@ Together, these provide the same experience as before, but with added control to
 
 **Notice that it's now a function instead of a property**
 
+### `QueryStatus` has been changed from an [enum](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) to a [union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)
+
+So, if you were checking the status property of a query or mutation against a QueryStatus enum property you will have to check it now against the string literal the enum previously held for each property.
+
+Therefore you have to change the enum properties to their equivalent string literal, like this:
+- `QueryStatus.Idle` -> `'idle'`
+- `QueryStatus.Loading` -> `'loading'`
+- `QueryStatus.Error` -> `'error'`
+- `QueryStatus.Success` -> `'success'`
+
+This is an example of how you would have done it in the previous version:
+
+```js
+import { QueryStatus } from 'react-query';
+
+const { data, status } = useQuery(['post', id], (_key, id) => fetchPost(id))
+
+if (status === QueryStatus.Loading) {
+  ...
+}
+
+if (status === QueryStatus.Error) {
+  ...
+}
+```
+
+And this is how it is now in version 3:
+
+```js
+const { data, status } = useQuery(['post', id], () => fetchPost(id))
+
+if (status === 'loading') {
+  ...
+}
+
+if (status === 'error') {
+  ...
+}
+```
+
 ### The `useQueryCache` hook has been replaced by the `useQueryClient` hook.
 
 It returns the provided `queryClient` for its component tree and shouldn't need much tweaking beyond a rename.

--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -434,8 +434,7 @@ Here is an example of the changes you would have to make:
 - import { useQuery, QueryStatus } from 'react-query';
 + import { useQuery } from 'react-query';
 
-- const { data, status } = useQuery(['post', id], (_key, id) => fetchPost(id))
-+ const { data, status } = useQuery(['post', id], () => fetchPost(id))
+const { data, status } = useQuery(['post', id], () => fetchPost(id))
 
 - if (status === QueryStatus.Loading) {
 + if (status === 'loading') {

--- a/docs/src/pages/guides/migrating-to-react-query-3.md
+++ b/docs/src/pages/guides/migrating-to-react-query-3.md
@@ -116,46 +116,6 @@ Together, these provide the same experience as before, but with added control to
 
 **Notice that it's now a function instead of a property**
 
-### `QueryStatus` has been changed from an [enum](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) to a [union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)
-
-So, if you were checking the status property of a query or mutation against a QueryStatus enum property you will have to check it now against the string literal the enum previously held for each property.
-
-Therefore you have to change the enum properties to their equivalent string literal, like this:
-- `QueryStatus.Idle` -> `'idle'`
-- `QueryStatus.Loading` -> `'loading'`
-- `QueryStatus.Error` -> `'error'`
-- `QueryStatus.Success` -> `'success'`
-
-This is an example of how you would have done it in the previous version:
-
-```js
-import { QueryStatus } from 'react-query';
-
-const { data, status } = useQuery(['post', id], (_key, id) => fetchPost(id))
-
-if (status === QueryStatus.Loading) {
-  ...
-}
-
-if (status === QueryStatus.Error) {
-  ...
-}
-```
-
-And this is how it is now in version 3:
-
-```js
-const { data, status } = useQuery(['post', id], () => fetchPost(id))
-
-if (status === 'loading') {
-  ...
-}
-
-if (status === 'error') {
-  ...
-}
-```
-
 ### The `useQueryCache` hook has been replaced by the `useQueryClient` hook.
 
 It returns the provided `queryClient` for its component tree and shouldn't need much tweaking beyond a rename.
@@ -455,6 +415,38 @@ setConsole({
 ```
 
 In version 3 **this is done automatically when React Query is used in React Native**.
+
+
+### Typescript
+#### `QueryStatus` has been changed from an [enum](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) to a [union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)
+
+So, if you were checking the status property of a query or mutation against a QueryStatus enum property you will have to check it now against the string literal the enum previously held for each property.
+
+Therefore you have to change the enum properties to their equivalent string literal, like this:
+- `QueryStatus.Idle` -> `'idle'`
+- `QueryStatus.Loading` -> `'loading'`
+- `QueryStatus.Error` -> `'error'`
+- `QueryStatus.Success` -> `'success'`
+
+Here is an example of the changes you would have to make:
+
+```diff
+- import { useQuery, QueryStatus } from 'react-query';
++ import { useQuery } from 'react-query';
+
+- const { data, status } = useQuery(['post', id], (_key, id) => fetchPost(id))
++ const { data, status } = useQuery(['post', id], () => fetchPost(id))
+
+- if (status === QueryStatus.Loading) {
++ if (status === 'loading') {
+  ...
+}
+
+- if (status === QueryStatus.Error) {
++ if (status === 'error') {
+  ...
+}
+```
 
 ## New features
 


### PR DESCRIPTION
### Description

In version 2 the `QueryStatus` typing was:
```typescript
export enum QueryStatus {
  Idle = 'idle',
  Loading = 'loading',
  Error = 'error',
  Success = 'success',
}
```
https://github.com/tannerlinsley/react-query/blame/8aeb209c3b9c84382a88059afbc398be93a69b33/src/core/types.ts#L183

And now in version 3 is:
```typescript
export type QueryStatus = 'idle' | 'loading' | 'error' | 'success'
```
https://github.com/tannerlinsley/react-query/blame/7b14ef519a544d725f2cff99574f0a01f92b8c94/src/core/types.ts#L257

### Changes
- documented the change described above
- added underline to links that are children of headings
  ![image](https://user-images.githubusercontent.com/3933427/113420553-d408fb00-93c9-11eb-87cc-8b253368c4b0.png)
  ![image](https://user-images.githubusercontent.com/3933427/113420499-b9cf1d00-93c9-11eb-88f8-7131e974abb7.png)
  this affects anchor links but these already have an underline property set, so I think there's no issue with that
