### PR TITLE
Add TQueryKey to QueryFunction generic type in QueryOptions, remove ensureArray from Query

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -379,7 +379,7 @@ export class Query<
 
     // Create query function context
     const queryKey = ensureArray(this.queryKey)
-    const queryFnContext: QueryFunctionContext<unknown[]> = {
+    const queryFnContext: QueryFunctionContext<TQueryKey> = {
       queryKey,
       pageParam: undefined,
     }

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -378,7 +378,7 @@ export class Query<
     }
 
     // Create query function context
-    const queryKey = ensureArray(this.queryKey)
+    const queryKey = (ensureArray(this.queryKey) as unknown) as TQueryKey
     const queryFnContext: QueryFunctionContext<TQueryKey> = {
       queryKey,
       pageParam: undefined,

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -1,6 +1,5 @@
 import {
   Updater,
-  ensureArray,
   functionalUpdate,
   isValidTimeout,
   noop,
@@ -393,7 +392,7 @@ export class Query<
     const context: FetchContext<TQueryFnData, TError, TData, any> = {
       fetchOptions,
       options: this.options,
-      queryKey: ensureArray(this.queryKey),
+      queryKey: this.queryKey,
       state: this.state,
       fetchFn,
     }

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -378,9 +378,8 @@ export class Query<
     }
 
     // Create query function context
-    const queryKey = (ensureArray(this.queryKey) as unknown) as TQueryKey
     const queryFnContext: QueryFunctionContext<TQueryKey> = {
-      queryKey,
+      queryKey: this.queryKey,
       pageParam: undefined,
     }
 
@@ -394,7 +393,7 @@ export class Query<
     const context: FetchContext<TQueryFnData, TError, TData, any> = {
       fetchOptions,
       options: this.options,
-      queryKey,
+      queryKey: ensureArray(this.queryKey),
       state: this.state,
       fetchFn,
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -59,7 +59,7 @@ export interface QueryOptions<
   retryDelay?: RetryDelayValue<TError>
   cacheTime?: number
   isDataEqual?: (oldData: TData | undefined, newData: TData) => boolean
-  queryFn?: QueryFunction<TQueryFnData>
+  queryFn?: QueryFunction<TQueryFnData, TQueryKey>
   queryHash?: string
   queryKey?: TQueryKey
   queryKeyHashFn?: QueryKeyHashFunction<TQueryKey>

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -16,6 +16,7 @@ import {
   QueryClient,
   UseQueryResult,
   QueryCache,
+  QueryFunction,
   QueryFunctionContext,
 } from '../..'
 
@@ -74,6 +75,20 @@ describe('useQuery', () => {
       })
       expectType<string | undefined>(fromGenericOptionsQueryFn.data)
       expectType<unknown>(fromGenericOptionsQueryFn.error)
+
+      type MyData = number
+      type MyQueryKey = readonly ['my-data', number]
+
+      const getMyData: QueryFunction<MyData, MyQueryKey> = async ({
+        queryKey: [, n],
+      }) => {
+        return n + 42
+      }
+
+      useQuery({
+        queryKey: ['my-data', 100],
+        queryFn: getMyData,
+      })
     }
   })
 


### PR DESCRIPTION
This PR fixes the following edge case issue in typings:

```ts
import { QueryFunction, useQuery } from "react-query";

type MyData = number;
type MyQueryKey = readonly ["my-data", number];

const getMyData: QueryFunction<MyData, MyQueryKey> = async ({
  queryKey: [, n],
}) => {
  return n + 42;
};

// ...

const myData = useQuery({
  queryKey: ["my-data", 100],
  queryFn: getMyData,
});
```

**Before**

```
No overload matches this call.
  Overload 1 of 3, '(options: UseQueryOptions<number, unknown, number, (string | number)[]>): UseQueryResult<number, unknown>', gave the following error.
    Type 'QueryFunction<number, MyQueryKey>' is not assignable to type 'QueryFunction<number, QueryKey>'.
      Type 'QueryKey' is not assignable to type 'MyQueryKey'.
        Type 'string' is not assignable to type 'readonly ["my-data", number]'.
  Overload 2 of 3, '(queryKey: QueryKey, options?: UseQueryOptions<unknown, unknown, unknown, QueryKey> | undefined): UseQueryResult<unknown, unknown>', gave the following error.
    Argument of type '{ queryKey: (string | number)[]; queryFn: QueryFunction<number, MyQueryKey>; }' is not assignable to parameter of type 'QueryKey'.
      Object literal may only specify known properties, and 'queryKey' does not exist in type 'readonly unknown[]'.ts(2769)
types.d.ts(32, 5): The expected type comes from property 'queryFn' which is declared here on type 'UseQueryOptions<number, unknown, number, (string | number)[]>'
```

**After**

No TS error

