### PR TITLE
docs(useQuery): add the useErrorBoundary option

### DIFF
--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -165,6 +165,9 @@ const result = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.
+- `useErrorBoundary: boolean`
+  - Defaults to the global query config's `useErrorBoundary` value, which is false
+  - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -167,7 +167,7 @@ const result = useQuery({
   - If set to `false`, structural sharing between query results will be disabled.
 - `useErrorBoundary: boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is false
-  - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
+  - Set this to true if you want errors to be thrown in the render phase and propagated to the nearest error boundary
 
 **Returns**
 


### PR DESCRIPTION
`useErrorBoundary` is listed as a valid option in the useQuery [API reference](https://react-query.tanstack.com/reference/useQuery), however, an actual explanation is missing. This PR adds one. 

![CleanShot 2021-04-04 at 18 28 33@2x](https://user-images.githubusercontent.com/10930234/113515274-c2fbed80-9573-11eb-9ef7-de1107903b18.png)
