### PR TITLE
Add `undefined` return type in onMutate 

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -472,7 +472,7 @@ export interface MutationOptions<
   mutationFn?: MutationFunction<TData, TVariables>
   mutationKey?: MutationKey
   variables?: TVariables
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | undefined
+  onMutate?: (variables: TVariables) => Promise<TContext> | Promise<undefined> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -472,7 +472,7 @@ export interface MutationOptions<
   mutationFn?: MutationFunction<TData, TVariables>
   mutationKey?: MutationKey
   variables?: TVariables
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | void
+  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -472,7 +472,7 @@ export interface MutationOptions<
   mutationFn?: MutationFunction<TData, TVariables>
   mutationKey?: MutationKey
   variables?: TVariables
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext
+  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | void
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -75,7 +75,7 @@ export interface UseMutationOptions<
   TContext = unknown
 > {
   mutationKey?: string | unknown[]
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext
+  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | void
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -75,7 +75,7 @@ export interface UseMutationOptions<
   TContext = unknown
 > {
   mutationKey?: string | unknown[]
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | void
+  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -75,7 +75,7 @@ export interface UseMutationOptions<
   TContext = unknown
 > {
   mutationKey?: string | unknown[]
-  onMutate?: (variables: TVariables) => Promise<TContext> | TContext | undefined
+  onMutate?: (variables: TVariables) => Promise<TContext> | Promise<undefined> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,


### PR DESCRIPTION
[useMutation](https://react-query.tanstack.com/reference/useMutation) has void return type but in code has not

In my code

```js
  const onMutate = () => {
    const previous = queryClient.getQueryData<CartProductsDataType>(queryKey);
    return previous;
  };
  const onError = (error: any, variable: AddOptionItem, context: CartProductsDataType | undefined) => {
    queryClient.setQueryData(queryKey, context);
  };

  return useMutation(QueryKey.CARTS, mutateFn, {
    onMutate,
    onError,
  });
```

onMutate return `CartProductsDataType or undefind` because of `getQueryData` but in useMutation error!!!
because useMutation onMutate function type only return `Promise<Context> or Context` not has `undefined`
so i try to add `undefined` type in onMutate return type

