### PR TITLE
fix(query): add isStale to QueryState type

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -48,6 +48,7 @@ export interface QueryState<TData = unknown, TError = unknown> {
   isFetching: boolean
   isInvalidated: boolean
   isPaused: boolean
+  isStale: boolean
   status: QueryStatus
 }
 
@@ -509,6 +510,7 @@ export class Query<
       isFetching: false,
       isInvalidated: false,
       isPaused: false,
+      isStale: false,
       status: hasData ? 'success' : 'idle',
     }
   }


### PR DESCRIPTION
While writing Vue binding for this library I stumbled upon typing error.
Devtools use a property that is not available on types exported by the lib:
https://github.com/tannerlinsley/react-query/blob/master/src/devtools/utils.ts#L13

This generates an error:
https://github.com/DamianOsipiuk/vue-react-query/blob/main/src/devtools/utils.ts#L15

Therefore adding this property to the types