### PR TITLE
refactor: remove redundant isStale utility

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { matchSorter } from 'match-sorter'
 import { useQueryClient } from '../react'
 import useLocalStorage from './useLocalStorage'
-import { useSafeState, isStale } from './utils'
+import { useSafeState } from './utils'
 
 import {
   Panel,
@@ -305,7 +305,7 @@ export function ReactQueryDevtools({
 }
 
 const getStatusRank = q =>
-  q.state.isFetching ? 0 : !q.observers.length ? 3 : isStale(q) ? 2 : 1
+  q.state.isFetching ? 0 : !q.observers.length ? 3 : q.isStale() ? 2 : 1
 
 const sortFns = {
   'Status > Last Updated': (a, b) =>

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -7,16 +7,10 @@ import useMediaQuery from './useMediaQuery'
 
 export const isServer = typeof window === 'undefined'
 
-export function isStale(query) {
-  return typeof query.isStale === 'function'
-    ? query.isStale()
-    : query.state.isStale
-}
-
 export function getQueryStatusColor(query, theme) {
   return query.state.isFetching
     ? theme.active
-    : isStale(query)
+    : query.isStale()
     ? theme.warning
     : !query.observers.length
     ? theme.gray
@@ -28,7 +22,7 @@ export function getQueryStatusLabel(query) {
     ? 'fetching'
     : !query.observers.length
     ? 'inactive'
-    : isStale(query)
+    : query.isStale()
     ? 'stale'
     : 'fresh'
 }


### PR DESCRIPTION
As noticed in [This PR](https://github.com/tannerlinsley/react-query/pull/2110) `isStale` utility function is redundant.

Therefore removing this utility function in favor of directly calling the function that is always available.