### PR TITLE
Fix useInfiniteQuery suspense bug

### DIFF
--- a/src/core/infiniteQueryObserver.ts
+++ b/src/core/infiniteQueryObserver.ts
@@ -75,6 +75,21 @@ export class InfiniteQueryObserver<
     })
   }
 
+  getOptimisticResult(
+    options: InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData
+    >
+  ): InfiniteQueryObserverResult<TData, TError> {
+    options.behavior = infiniteQueryBehavior()
+    return super.getOptimisticResult(options) as InfiniteQueryObserverResult<
+      TData,
+      TError
+    >
+  }
+
   fetchNextPage(
     options?: FetchNextPageOptions
   ): Promise<InfiniteQueryObserverResult<TData, TError>> {

--- a/src/react/tests/suspense.test.tsx
+++ b/src/react/tests/suspense.test.tsx
@@ -72,19 +72,20 @@ describe("useQuery's in Suspense mode", () => {
     const states: UseInfiniteQueryResult<number>[] = []
 
     function Page() {
+      const [multiplier, setMultiplier] = React.useState(1)
       const state = useInfiniteQuery(
-        key,
-        ({ pageParam = 0 }) => Number(pageParam),
+        `${key}_${multiplier}`,
+        ({ pageParam = 1 }) => Number(pageParam * multiplier),
         {
           suspense: true,
           getNextPageParam: lastPage => lastPage + 1,
         }
       )
       states.push(state)
-      return null
+      return <button onClick={() => setMultiplier(2)}>next</button>
     }
 
-    renderWithClient(
+    const rendered = renderWithClient(
       queryClient,
       <React.Suspense fallback="loading">
         <Page />
@@ -95,7 +96,16 @@ describe("useQuery's in Suspense mode", () => {
 
     expect(states.length).toBe(1)
     expect(states[0]).toMatchObject({
-      data: { pages: [0], pageParams: [undefined] },
+      data: { pages: [1], pageParams: [undefined] },
+      status: 'success',
+    })
+
+    fireEvent.click(rendered.getByText('next'))
+    await sleep(10)
+
+    expect(states.length).toBe(3)
+    expect(states[2]).toMatchObject({
+      data: { pages: [2], pageParams: [undefined] },
       status: 'success',
     })
   })

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -81,7 +81,7 @@ export function useBaseQuery<
     >(queryClient, defaultedOptions)
   }
 
-  let result = obsRef.current.getOptimisticResult(defaultedOptions)
+  let result = obsRef.current.getOptimisticResult(obsRef.current.options)
 
   React.useEffect(() => {
     mountedRef.current = true

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -80,7 +80,6 @@ export function useBaseQuery<
       TQueryKey
     >(queryClient, defaultedOptions)
   }
-  defaultedOptions.behavior = obsRef.current.options.behavior
 
   let result = obsRef.current.getOptimisticResult(defaultedOptions)
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -80,8 +80,9 @@ export function useBaseQuery<
       TQueryKey
     >(queryClient, defaultedOptions)
   }
+  defaultedOptions.behavior = obsRef.current.options.behavior
 
-  let result = obsRef.current.getOptimisticResult(obsRef.current.options)
+  let result = obsRef.current.getOptimisticResult(defaultedOptions)
 
   React.useEffect(() => {
     mountedRef.current = true


### PR DESCRIPTION
Closes: https://github.com/tannerlinsley/react-query/issues/2095

This fixes the useInfiniteQuery suspense bug where `options.behavior` was missing and so `infiniteQueryBehavior.onFetch` was not being called, resulting incorrect query `data`.
