### PR TITLE
Fix "No queryClient set" when hydrating

### DIFF
--- a/src/hydration/react.tsx
+++ b/src/hydration/react.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useQueryClient } from '../react'
+import { useQueryClient } from 'react-query'
 import { hydrate, HydrateOptions } from './hydration'
 
 export function useHydrate(state: unknown, options?: HydrateOptions) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "strict": true,
-    "types": ["jest"]
+    "types": ["jest"],
+    "paths": {
+      "react-query": ["./src/index.ts"]
+    }
   },
   "include": ["./src"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -4,7 +4,10 @@
     "declaration": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "noEmit": false
+    "noEmit": false,
+    "paths": {
+      "react-query": ["./src/index.ts"]
+    }
   },
   "files": [
     "./src/index.ts",


### PR DESCRIPTION
Closes #2112 

This PR changes the relative import of `useQueryClient` to an absolute one (`from 'react-query'`). As described in the issue, this is important to avoid bundling parts of the main package into the hydration entry point and fixes a bug caused by the `QueryClientProvider`-context not lining up between the different entry points.

I've verified this fixes the broken NextJS-example as well as our code base at work.

Also added TS-resolves for this path so TS knows where to look for the types.

There are more relative imports in the hydration package, but they are all related to types which is fine.