### PR TITLE
Added hydrate and dehydrate options to the persistQueryClient function

### DIFF
--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -94,6 +94,10 @@ interface PersistQueryClientOptions {
   /** A unique string that can be used to forcefully
    * invalidate existing caches if they do not share the same buster string */
   buster?: string
+  /** The options passed to the hydrate function */
+  hydrateOptions?: HydrateOptions
+  /** The options passed to the dehydrate function */
+  dehydrateOptions?: DehydrateOptions
 }
 ```
 


### PR DESCRIPTION
The reason to add this is to be able to customize the hydrate/dehydrate behaviour on the persistQueryClient. For instance, I don't want a network error to remove a cache entry from my persisted state, I want the client cache to be equivalent to the persisted cache at all time, with dehydrate options, I can achieve this behaviour.