### PR TITLE
fix: do not throw errors while a query is retrying

### DIFF
--- a/src/react/tests/QueryResetErrorBoundary.test.tsx
+++ b/src/react/tests/QueryResetErrorBoundary.test.tsx
@@ -131,6 +131,66 @@ describe('QueryErrorResetBoundary', () => {
     consoleMock.mockRestore()
   })
 
+  it('should retry fetch if the reset error boundary has been reset and the query contains data from a previous fetch', async () => {
+    const key = queryKey()
+
+    let succeed = false
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      const { data } = useQuery(
+        key,
+        async () => {
+          await sleep(10)
+          if (!succeed) {
+            throw new Error('Error')
+          } else {
+            return 'data'
+          }
+        },
+        {
+          retry: false,
+          useErrorBoundary: true,
+          initialData: 'initial',
+        }
+      )
+      return <div>{data}</div>
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            onReset={reset}
+            fallbackRender={({ resetErrorBoundary }) => (
+              <div>
+                <div>error boundary</div>
+                <button
+                  onClick={() => {
+                    resetErrorBoundary()
+                  }}
+                >
+                  retry
+                </button>
+              </div>
+            )}
+          >
+            <Page />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    )
+
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('retry'))
+    succeed = true
+    fireEvent.click(rendered.getByText('retry'))
+    await waitFor(() => rendered.getByText('data'))
+
+    consoleMock.mockRestore()
+  })
+
   it('should not retry fetch if the reset error boundary has not been reset after a previous reset', async () => {
     const key = queryKey()
 

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -130,7 +130,8 @@ export function useBaseQuery<
   // Handle error boundary
   if (
     (defaultedOptions.suspense || defaultedOptions.useErrorBoundary) &&
-    result.isError
+    result.isError &&
+    !result.isFetching
   ) {
     throw result.error
   }


### PR DESCRIPTION
Fixes https://github.com/tannerlinsley/react-query/issues/1863