### PR TITLE
fix: use MutationKey in UseMutationOptions

### DIFF
--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -4,6 +4,7 @@ import {
   InfiniteQueryObserverResult,
   MutateOptions,
   MutationStatus,
+  MutationKey,
   QueryObserverOptions,
   QueryObserverResult,
   QueryKey,
@@ -74,7 +75,7 @@ export interface UseMutationOptions<
   TVariables = void,
   TContext = unknown
 > {
-  mutationKey?: string | unknown[]
+  mutationKey?: MutationKey
   onMutate?: (variables: TVariables) => Promise<TContext> | Promise<undefined> | TContext | undefined
   onSuccess?: (
     data: TData,


### PR DESCRIPTION
i think this is the correct type, as it's already defined just not used.

also without it, we can't do this:

```typescript
const key = ['someKey'] as const // we don't want anyone mutating it
useMutation(fn,{ mutationKey: key }) // type error
```
