### PR TITLE
feat(queryClient): return QueryClient instance from mount function

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -72,7 +72,7 @@ export class QueryClient {
     this.mutationDefaults = []
   }
 
-  mount(): void {
+  mount(): QueryClient {
     this.unsubscribeFocus = focusManager.subscribe(() => {
       if (focusManager.isFocused() && onlineManager.isOnline()) {
         this.mutationCache.onFocus()
@@ -85,6 +85,8 @@ export class QueryClient {
         this.queryCache.onOnline()
       }
     })
+
+    return this;
   }
 
   unmount(): void {


### PR DESCRIPTION
Return QueryClient from mount function to allow to chain them
This is a convenience solution for a vue-query package, where user has to call mount manually