### PR TITLE
docs(Query Filters): Correct/Make More Exact: Query Filter Object Code Snippet Comments

### DIFF
--- a/docs/src/pages/guides/filters.md
+++ b/docs/src/pages/guides/filters.md
@@ -13,13 +13,13 @@ A query filter is an object with certain conditions to match a query with:
 // Cancel all queries
 await queryClient.cancelQueries()
 
-// Remove all inactive queries
+// Remove all inactive queries that begin with `posts` in the key
 queryClient.removeQueries('posts', { inactive: true })
 
 // Refetch all active queries
 await queryClient.refetchQueries({ active: true })
 
-// Refetch all active queries that begin with `post` in the key
+// Refetch all active queries that begin with `posts` in the key
 await queryClient.refetchQueries('posts', { active: true })
 ```
 


### PR DESCRIPTION
1. Make comment in the code snippet for `removeQueries` more exact
2. correct comment for `refetchQueries` used for `posts` query key, to use 'posts' instead of 'post'.