### PR TITLE
Add curly brackets to mutation example for TypeScript error

### DIFF
--- a/docs/src/pages/guides/updates-from-mutation-responses.md
+++ b/docs/src/pages/guides/updates-from-mutation-responses.md
@@ -9,7 +9,9 @@ When dealing with mutations that **update** objects on the server, it's common f
 const queryClient = useQueryClient()
 
 const mutation = useMutation(editTodo, {
-  onSuccess: data => queryClient.setQueryData(['todo', { id: 5 }], data),
+  onSuccess: data => {
+    queryClient.setQueryData(['todo', { id: 5 }], data)
+  }
 })
 
 mutation.mutate({


### PR DESCRIPTION
This adds curly brackets to the arrow function which "disables" the implicit return value for TypeScript users, who see an error for this example.

CodeSandbox, which shows the error:

![image](https://user-images.githubusercontent.com/29319414/116005070-af3d2780-a605-11eb-82a4-f18a93606aef.png)

https://codesandbox.io/s/laughing-chaplygin-u1mdr?file=/src/App.tsx