### PR TITLE
fix: Node 16 Invalid 'main' field warning from devtools

### DIFF
--- a/devtools/package.json
+++ b/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "internal": true,
-  "main": "/index.js",
-  "module": "/index.js",
+  "main": "./index.js",
+  "module": "./index.js",
   "types": "../types/devtools/index.d.ts"
 }


### PR DESCRIPTION
Simple fix to remove the `DeprecationWarning: Invalid 'main' field` warning that comes up now on Node 16.x . I just fixed the `main` and `module` paths in `devtools/package.json` to be relative to their current directory.

Fixes #2233