### PR TITLE
feat: resetQueries disable refetch option

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -179,7 +179,7 @@ export class QueryClient {
     arg1?: QueryKey | QueryFilters,
     arg2?: QueryFilters | ResetOptions,
     arg3?: ResetOptions
-  ): Promise<void> {
+  ): Promise<void> | void {
     const [filters, options] = parseFilterArgs(arg1, arg2, arg3)
     const queryCache = this.queryCache
 
@@ -192,6 +192,11 @@ export class QueryClient {
       queryCache.findAll(filters).forEach(query => {
         query.reset()
       })
+
+      if (options?.disableRefetch === true) {
+        return
+      }
+
       return this.refetchQueries(refetchFilters, options)
     })
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -251,6 +251,7 @@ export interface InvalidateOptions {
 
 export interface ResetOptions {
   throwOnError?: boolean
+  disableRefetch?: boolean
 }
 
 export interface FetchNextPageOptions extends ResultOptions {


### PR DESCRIPTION
I used resetQueries function when user logged out, but this function always refetching queries.
Someone like me, maybe don't want to refetch when call resetQueries.
 
So I added new option for resetQueries.