### PR TITLE
docs: document that setDefaultOptions overwrites previous defaults

### DIFF
--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -410,7 +410,7 @@ const defaultOptions = queryClient.getDefaultOptions()
 
 ## `queryClient.setDefaultOptions`
 
-The `setDefaultOptions` method can be used to dynamically set the default options for this queryClient.
+The `setDefaultOptions` method can be used to dynamically set the default options for this queryClient. Previously defined default options will be overwritten.
 
 ```js
 queryClient.setDefaultOptions({


### PR DESCRIPTION
I noticed my default `staleTime` wasn't applying after I introduced a utility to namespace query keys. This was because I'd assumed `setDefaultOptions` would merge with previously-defined defaults, but it doesn't.

I fixed this in my project by merging with a default config object:

```diff
+ import { merge } from "lodash";
```

And then:

```diff
- queryClient.setDefaultOptions({
-     queries: {
-         queryKeyHashFn: myFunction,
-     },
- });
+ queryClient.setDefaultOptions(
+     merge<DefaultOptions, DefaultOptions>(
+         {
+             queries: {
+                 queryKeyHashFn: myFunction,
+             },
+         },
+         DEFAULT_QUERY_CLIENT_OPTIONS
+     )
+ );
```

I'm opening this PR to discuss mentioning this behavior in the docs. Additionally, `setDefaultOptions` could take a function where the existing options get passed.