### PR TITLE
docs: fix typo/outdated hook reference

### DIFF
--- a/docs/src/pages/reference/hydration/HydrateComp.md
+++ b/docs/src/pages/reference/hydration/HydrateComp.md
@@ -3,7 +3,7 @@ id: hydration/HydrateComp
 title: hydration/Hydrate
 ---
 
-`hydration/Hydrate` adds a previously dehydrated state into the `queryClient` that would returned by running `useQueryCache`. If the client already contains data, the new queries will be intelligently merged based on update timestamp.
+`hydration/Hydrate` adds a previously dehydrated state into the `queryClient` that would be returned by `useQueryClient()`. If the client already contains data, the new queries will be intelligently merged based on update timestamp.
 
 ```js
 import { Hydrate } from 'react-query/hydration'


### PR DESCRIPTION
In docs for `Hydrate` component, fixes reference to outdated `useQueryCache` hook, plus minor grammatical edits.