### PR TITLE
Hide devtools when closed, prevent focus

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -407,9 +407,16 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
 
     React.useEffect(() => {
       if (isOpen) {
-        return queryCache.subscribe(() => {
+        const unsubscribe = queryCache.subscribe(() => {
           setUnsortedQueries(Object.values(queryCache.getAll()))
         })
+        // re-subscribing after the panel is closed and re-opened won't trigger the callback,
+        // So we'll manually populate our state
+        setUnsortedQueries(Object.values(queryCache.getAll()))
+
+        return () => {
+          unsubscribe()
+        }
       }
       return undefined
     }, [isOpen, sort, sortFn, sortDesc, setUnsortedQueries, queryCache])

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -214,7 +214,7 @@ export function ReactQueryDevtools({
             borderTop: `1px solid ${theme.gray}`,
             transformOrigin: 'top',
             // visibility will be toggled after transitions, but set initial state here
-            visibility: initialIsOpen ? 'visible' : 'hidden',
+            visibility: isOpen ? 'visible' : 'hidden',
             ...panelStyle,
             ...(isResizing
               ? {

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -133,23 +133,23 @@ export function ReactQueryDevtools({
     setIsResolvedOpen(isOpen)
   }, [isOpen, isResolvedOpen, setIsResolvedOpen])
 
-  const handlePanelTransitionStart = React.useCallback(() => {
-    if (panelRef.current && isResolvedOpen) {
-      panelRef.current.style.visibility = 'visible'
-    }
-  }, [isResolvedOpen])
-
-  const handlePanelTransitionEnd = React.useCallback(() => {
-    if (panelRef.current && !isResolvedOpen) {
-      panelRef.current.style.visibility = 'hidden'
-    }
-  }, [isResolvedOpen])
-
   // Toggle panel visibility before/after transition (depending on direction).
   // Prevents focusing in a closed panel.
   React.useEffect(() => {
-    if (panelRef.current) {
-      const ref = panelRef.current
+    const ref = panelRef.current
+    if (ref) {
+      function handlePanelTransitionStart() {
+        if (ref && isResolvedOpen) {
+          ref.style.visibility = 'visible'
+        }
+      }
+
+      function handlePanelTransitionEnd() {
+        if (ref && !isResolvedOpen) {
+          ref.style.visibility = 'hidden'
+        }
+      }
+
       ref.addEventListener('transitionstart', handlePanelTransitionStart)
       ref.addEventListener('transitionend', handlePanelTransitionEnd)
 
@@ -158,7 +158,7 @@ export function ReactQueryDevtools({
         ref.removeEventListener('transitionend', handlePanelTransitionEnd)
       }
     }
-  }, [handlePanelTransitionStart, handlePanelTransitionEnd])
+  }, [isResolvedOpen])
 
   React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
     if (isResolvedOpen) {
@@ -414,9 +414,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
         // So we'll manually populate our state
         setUnsortedQueries(Object.values(queryCache.getAll()))
 
-        return () => {
-          unsubscribe()
-        }
+        return unsubscribe
       }
       return undefined
     }, [isOpen, sort, sortFn, sortDesc, setUnsortedQueries, queryCache])


### PR DESCRIPTION
Fixes #2375.

Previously, opening and closing the devtools only changed it opacity (and subscribed/unsubscribed to queries).  That meant that it was still possible to tab through the elements in the panel, even when it was closed.

With this change, when the panel starts out closed, we set a `visibility: hidden` style, so that it is gone from both the accessibility tree and the tab order.  I've also set up transition listeners so that before a transition starts, if the devtools are opening, we turn visibility to visible, so that the opacity fade-in works correctly.  Likewise, on a transition end, we check if the panel is closed, and turn visibility to hidden.

I tested this by compiling, copying the built files into my project's node_modules, and running my app, and it worked as I expected.  The fade still occurs (both in and out), focus does not move into a closed devtools, and the devtools are hidden in the accessibility tree. 

This probably would have been more straightforward with a keyframe animation, but I am not sure how to do that using inline styles, or whether its even possible.