### PR TITLE
fix: display devtools only in development

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -1,4 +1,4 @@
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV !== 'development') {
   module.exports = {
     ReactQueryDevtools: function () {
       return null


### PR DESCRIPTION
As discussed with @tannerlinsley in #2381, this PR changes the current Devtools render behavior to only render the component when `NODE_ENV === 'development'`.

The current verification only disables Devtools for production mode, which causes Devtools to be rendered when `NODE_ENV === 'test'` and creates some issues on tests such as Devtools being rendered on snapshots and triggering a lot of jests warnings. This PR solves this issue.