### PR TITLE
docs: Fix isMutatingPosts example

### DIFF
--- a/docs/src/pages/reference/useIsMutating.md
+++ b/docs/src/pages/reference/useIsMutating.md
@@ -10,7 +10,7 @@ import { useIsMutating } from 'react-query'
 // How many mutations are fetching?
 const isMutating = useIsMutating()
 // How many mutations matching the posts prefix are fetching?
-const isMutatingPosts = useIsMutating(['posts'])
+const isMutatingPosts = useIsMutating({ mutationKey: 'posts' })
 ```
 
 **Options**


### PR DESCRIPTION
Previously the example was using an array as argument, which doesn't match the newest API.