### PR TITLE
docs: update query function usage examples

### DIFF
--- a/docs/src/pages/guides/query-functions.md
+++ b/docs/src/pages/guides/query-functions.md
@@ -8,12 +8,12 @@ A query function can be literally any function that **returns a promise**. The p
 All of the following are valid query function configurations:
 
 ```js
-useQuery(['todos', todoId], fetchTodoById)
 useQuery(['todos', todoId], () => fetchTodoById(todoId))
 useQuery(['todos', todoId], async () => {
   const data = await fetchTodoById(todoId)
   return data
 })
+useQuery(['todos', todoId], ({ queryKey }) => fetchTodoById(queryKey[1]))
 ```
 
 ## Handling and Throwing Errors

--- a/docs/src/pages/guides/query-functions.md
+++ b/docs/src/pages/guides/query-functions.md
@@ -8,6 +8,7 @@ A query function can be literally any function that **returns a promise**. The p
 All of the following are valid query function configurations:
 
 ```js
+useQuery(['todos'], fetchAllTodos)
 useQuery(['todos', todoId], () => fetchTodoById(todoId))
 useQuery(['todos', todoId], async () => {
   const data = await fetchTodoById(todoId)


### PR DESCRIPTION
[Per the v3 breaking changes, query key parts are not automatically spread to query functions.](https://react-query.tanstack.com/guides/migrating-to-react-query-3#query-key-partspieces-are-no-longer-automatically-spread-to-the-query-function)

I've removed an old usage example that did it this way and added an example using `context.queryKey` instead.