### PR TITLE
Stale While Revalidate - Update comparison.md

### DIFF
--- a/docs/src/pages/comparison.md
+++ b/docs/src/pages/comparison.md
@@ -47,7 +47,7 @@ Feature/Capability Key:
 | Prefetching APIs                                   | ✅                                       | 🔶                         | ✅                                    | ✅                                   |
 | Query Cancellation                                 | ✅                                       | 🛑                         | 🛑                                    | 🛑                                   |
 | Partial Query Matching<sup>3</sup>                 | ✅                                       | 🛑                         | 🛑                                    | ✅                                   |
-| Stale While Revalidate                             | ✅                                       | ✅                         | 🛑                                    | ✅                                   |
+| Stale While Revalidate                             | ✅                                       | ✅                         | ✅                                    | ✅                                   |
 | Stale Time Configuration                           | ✅                                       | 🛑                         | 🛑                                    | ✅                                   |
 | Pre-usage Query/Mutation Configuration<sup>4</sup> | ✅                                       | 🛑                         | 🛑                                    | ✅                                   |
 | Window Focus Refetching                            | ✅                                       | ✅                         | 🛑                                    | 🔶                                   |


### PR DESCRIPTION
Stale While Revalidate contains incorrect information in the comparison table.

See Apollo [docs here](https://www.apollographql.com/docs/react/data/queries/#cache-and-network) which explain: 

> Apollo Client executes the full query against both the cache and your GraphQL server. The query automatically updates if the result of the server-side query modifies cached fields.


Addresses #2151 