### PR TITLE
fix: rename asyncStoragePersistor to createAsyncStoragePersistor

### DIFF
--- a/docs/src/pages/plugins/createAsyncStoragePersistor.md
+++ b/docs/src/pages/plugins/createAsyncStoragePersistor.md
@@ -17,7 +17,7 @@ This utility comes packaged with `react-query` and is available under the `react
 - Pass it to the [`persistQueryClient`](../persistQueryClient) function
 
 ```ts
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental'
 import { createAsyncStoragePersistor } from 'react-query/createAsyncStoragePersistor-experimental'
 
@@ -56,7 +56,7 @@ interface CreateAsyncStoragePersistorOptions {
   /** The storage client used for setting an retrieving items from cache */
   storage: AsyncStorage
   /** The key to use when storing the cache to localstorage */
-  asyncStorageKey?: string
+  key?: string
   /** To avoid localstorage spamming,
    * pass a time in ms to throttle saving the cache to disk */
   throttleTime?: number
@@ -73,7 +73,7 @@ The default options are:
 
 ```js
 {
-  asyncStorageKey = `REACT_QUERY_OFFLINE_CACHE`,
+  key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
 }
 ```

--- a/src/createAsyncStoragePersistor-experimental/index.ts
+++ b/src/createAsyncStoragePersistor-experimental/index.ts
@@ -1,7 +1,9 @@
+import { PersistedClient, Persistor } from '../persistQueryClient-experimental'
+
 interface AsyncStorage {
-  getItem: (key: string) => Promise<string>
-  setItem: (key: string, value: string) => Promise<unknown>
-  removeItem: (key: string) => Promise<unknown>
+  getItem: (key: string) => Promise<string | null>
+  setItem: (key: string, value: string) => Promise<void>
+  removeItem: (key: string) => Promise<void>
 }
 
 interface CreateAsyncStoragePersistorOptions {
@@ -14,11 +16,11 @@ interface CreateAsyncStoragePersistorOptions {
   throttleTime?: number
 }
 
-export const asyncStoragePersistor = ({
+export const createAsyncStoragePersistor = ({
   storage,
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
-}: CreateAsyncStoragePersistorOptions) => {
+}: CreateAsyncStoragePersistorOptions): Persistor => {
   return {
     persistClient: asyncThrottle(
       persistedClient => storage.setItem(key, JSON.stringify(persistedClient)),
@@ -31,7 +33,7 @@ export const asyncStoragePersistor = ({
         return
       }
 
-      return JSON.parse(cacheString)
+      return JSON.parse(cacheString) as PersistedClient
     },
     removeClient: () => storage.removeItem(key),
   }


### PR DESCRIPTION
## Why
This function was being called as `createAsyncStoragePersistor` in the docs but was exported as `asyncStoragePersistor`

 ![Screenshot from 2021-06-30 16-20-02](https://user-images.githubusercontent.com/6487206/124019130-0ae9af80-d9bf-11eb-99a5-2534231a16ca.png)
