### PR TITLE
test(devtools): Add base tests for react-query devtools

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -333,7 +333,7 @@ const sortFns = {
       ? 1
       : -1,
   'Query Hash': (a, b) => (a.queryHash > b.queryHash ? 1 : -1),
-  'Last Updated': (a, b) => (a.state.updatedAt < b.state.updatedAt ? 1 : -1),
+  'Last Updated': (a, b) => (a.state.dataUpdatedAt < b.state.dataUpdatedAt ? 1 : -1),
 }
 
 export const ReactQueryDevtoolsPanel = React.forwardRef(
@@ -566,6 +566,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                   {!filter ? (
                     <>
                       <Select
+                        aria-label="Sort queries"
                         value={sort}
                         onChange={e => setSort(e.target.value)}
                         style={{

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -333,7 +333,8 @@ const sortFns = {
       ? 1
       : -1,
   'Query Hash': (a, b) => (a.queryHash > b.queryHash ? 1 : -1),
-  'Last Updated': (a, b) => (a.state.dataUpdatedAt < b.state.dataUpdatedAt ? 1 : -1),
+  'Last Updated': (a, b) =>
+    a.state.dataUpdatedAt < b.state.dataUpdatedAt ? 1 : -1,
 }
 
 export const ReactQueryDevtoolsPanel = React.forwardRef(

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -240,6 +240,7 @@ export function ReactQueryDevtools({
         {isResolvedOpen ? (
           <Button
             type="button"
+            aria-label="Close React Query Devtools"
             {...otherCloseButtonProps}
             onClick={() => {
               setIsOpen(false)

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -552,6 +552,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                 >
                   <Input
                     placeholder="Filter"
+                    aria-label="Filter by queryhash"
                     value={filter ?? ''}
                     onChange={e => setFilter(e.target.value)}
                     onKeyDown={e => {
@@ -604,6 +605,8 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                 <div
                   suppressHydrationWarning
                   key={query.queryHash || i}
+                  role="button"
+                  aria-label={`Open query details for ${query.queryHash}`}
                   onClick={() =>
                     setActiveQueryHash(
                       activeQueryHash === query.queryHash ? '' : query.queryHash

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -282,10 +282,10 @@ describe('ReactQueryDevtools', () => {
     // to just the number, with the order being -> query-1, query-2, query-3
     fireEvent.change(sortSelect, { target: { value: 'Query Hash' } })
     /** To check the order of the queries we can use regex to find
-     * all the row items in an array and then compare the items 
+     * all the row items in an array and then compare the items
      * one by one in the order we expect it
      * @reference https://github.com/testing-library/react-testing-library/issues/313#issuecomment-625294327
-    */
+     */
     queries = await screen.findAllByText(/\["query-[1-3]"\]/)
     expect(queries[0]?.textContent).toEqual(query1Hash)
     expect(queries[1]?.textContent).toEqual(query2Hash)
@@ -300,7 +300,7 @@ describe('ReactQueryDevtools', () => {
     expect(queries[1]?.textContent).toEqual(query3Hash)
     expect(queries[2]?.textContent).toEqual(query1Hash)
 
-    // When sorted by the status and then last updated date the queries 
+    // When sorted by the status and then last updated date the queries
     // query-3 takes precedence because its stale time being infinity, it
     // always remains fresh, the rest of the queries are sorted by their last
     // updated time, so the resulting order is -> query-3, query-2, query-1
@@ -309,5 +309,13 @@ describe('ReactQueryDevtools', () => {
     expect(queries[0]?.textContent).toEqual(query3Hash)
     expect(queries[1]?.textContent).toEqual(query2Hash)
     expect(queries[2]?.textContent).toEqual(query1Hash)
+
+    // Switch the order form ascending to descending and expect the
+    // query order to be reversed from previous state
+    fireEvent.click(screen.getByRole('button', { name: /⬆ asc/i}))
+    queries = await screen.findAllByText(/\["query-[1-3]"\]/)
+    expect(queries[0]?.textContent).toEqual(query1Hash)
+    expect(queries[1]?.textContent).toEqual(query2Hash)
+    expect(queries[2]?.textContent).toEqual(query3Hash)
   })
 })

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -219,7 +219,7 @@ describe('ReactQueryDevtools', () => {
     const bazItem = screen.queryByText(bazQueryHash)
     expect(barItem).toBeNull()
     expect(bazItem).toBeNull()
-    
+
     fireEvent.change(filterInput, { target: { value: '' } })
   })
 

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -312,7 +312,7 @@ describe('ReactQueryDevtools', () => {
 
     // Switch the order form ascending to descending and expect the
     // query order to be reversed from previous state
-    fireEvent.click(screen.getByRole('button', { name: /⬆ asc/i}))
+    fireEvent.click(screen.getByRole('button', { name: /⬆ asc/i }))
     queries = await screen.findAllByText(/\["query-[1-3]"\]/)
     expect(queries[0]?.textContent).toEqual(query1Hash)
     expect(queries[1]?.textContent).toEqual(query2Hash)

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { QueryClient, QueryCache, useQuery } from '../..'
+import { renderWithClient, sleep } from './utils'
+
+describe('ReactQueryDevtools', () => {
+  const queryCache = new QueryCache()
+  const queryClient = new QueryClient({ queryCache })
+
+  it('should be able to open and close devtools', async () => {
+    function Page() {
+      const { data = 'default' } = useQuery('check', async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    console.log(queryCache.find('check')?.isFetching())
+
+    // Since the initial is open state is false, expect the close button to not be present
+    // in the DOM. Then find the open button and click on it.
+    const closeButton = screen.queryByRole('button', { name: /close react query devtools/i })
+    expect(closeButton).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /open react query devtools/i }))
+
+    // Wait for the animation to finish and the open button to be removed from DOM once the devtools
+    // is opened. Then find the close button and click on it.
+    await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /open react query devtools/i }))
+    fireEvent.click(screen.getByRole('button', { name: /close react query devtools/i }))
+
+    // Finally once the close animation is completed expect the open button to
+    // be present in the DOM again.
+    await screen.findByRole('button', { name: /open react query devtools/i })
+  })
+})
+
+export {}

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -1,11 +1,27 @@
 import React from 'react'
-import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import {
+  fireEvent,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { QueryClient, QueryCache, useQuery } from '../..'
-import { renderWithClient, sleep } from './utils'
+import { getByTextContent, renderWithClient, sleep } from './utils'
 
 describe('ReactQueryDevtools', () => {
   const queryCache = new QueryCache()
-  const queryClient = new QueryClient({ queryCache })
+  const queryClient = new QueryClient({
+    queryCache,
+    defaultOptions: {
+      queries: {
+        staleTime: 0,
+      },
+    },
+  })
+
+  beforeEach(() => {
+    queryCache.clear()
+  })
 
   it('should be able to open and close devtools', async () => {
     function Page() {
@@ -21,25 +37,109 @@ describe('ReactQueryDevtools', () => {
       )
     }
 
-    renderWithClient(queryClient, <Page />)
-
-    console.log(queryCache.find('check')?.isFetching())
+    renderWithClient(queryClient, <Page />, { initialIsOpen: false })
 
     // Since the initial is open state is false, expect the close button to not be present
     // in the DOM. Then find the open button and click on it.
-    const closeButton = screen.queryByRole('button', { name: /close react query devtools/i })
+    const closeButton = screen.queryByRole('button', {
+      name: /close react query devtools/i,
+    })
     expect(closeButton).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: /open react query devtools/i }))
+    fireEvent.click(
+      screen.getByRole('button', { name: /open react query devtools/i })
+    )
 
     // Wait for the animation to finish and the open button to be removed from DOM once the devtools
     // is opened. Then find the close button and click on it.
-    await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /open react query devtools/i }))
-    fireEvent.click(screen.getByRole('button', { name: /close react query devtools/i }))
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('button', { name: /open react query devtools/i })
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: /close react query devtools/i })
+    )
 
     // Finally once the close animation is completed expect the open button to
     // be present in the DOM again.
     await screen.findByRole('button', { name: /open react query devtools/i })
   })
-})
 
-export {}
+  it('should display the correct query states', async () => {
+    function Page() {
+      const { data = 'default' } = useQuery(
+        'check',
+        async () => {
+          await sleep(100)
+          return 'test'
+        },
+        { staleTime: 300 }
+      )
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    function PageParent() {
+      const [isPageVisible, setIsPageVisible] = React.useState(true)
+
+      return (
+        <div>
+          <button
+            type="button"
+            aria-label="Toggle page visibility"
+            onClick={() => setIsPageVisible(visible => !visible)}
+          >
+            Toggle Page
+          </button>
+          {isPageVisible && <Page />}
+        </div>
+      )
+    }
+
+    renderWithClient(queryClient, <PageParent />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open react query devtools/i })
+    )
+
+    // Find the current query from the cache
+    const currentQuery = queryCache.find('check')
+
+    // When the query is fetching then expect number of
+    // fetching queries to be 1
+    expect(currentQuery?.isFetching()).toEqual(true)
+    await screen.findByText(
+      getByTextContent('fresh (0) fetching (1) stale (0) inactive (0)')
+    )
+
+    // When we are done fetching the query doesn't go stale
+    // until 300ms after, so expect the number of fresh
+    // queries to be 1
+    await waitFor(() => {
+      expect(currentQuery?.isFetching()).toEqual(false)
+    })
+    await screen.findByText(
+      getByTextContent('fresh (1) fetching (0) stale (0) inactive (0)')
+    )
+
+    // Then wait for the query to go stale and then
+    // expect the number of stale queries to be 1
+    await waitFor(() => {
+      expect(currentQuery?.isStale()).toEqual(false)
+    })
+    await screen.findByText(
+      getByTextContent('fresh (0) fetching (0) stale (1) inactive (0)')
+    )
+
+    // Unmount the page component thus making the query inactive
+    // and expect number of inactive queries to be 1
+    fireEvent.click(
+      screen.getByRole('button', { name: /toggle page visibility/i })
+    )
+    await screen.findByText(
+      getByTextContent('fresh (0) fetching (0) stale (0) inactive (1)')
+    )
+  })
+})

--- a/src/devtools/tests/utils.tsx
+++ b/src/devtools/tests/utils.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import React from 'react'
 import { ReactQueryDevtools } from '../'
 
-import { QueryClient, QueryClientProvider } from '../..'
+import { QueryClient, QueryClientProvider, QueryCache } from '../..'
 
 export function renderWithClient(
   client: QueryClient,
@@ -35,7 +35,7 @@ export function sleep(timeout: number): Promise<void> {
 
 /**
  * This method is useful for matching by text content when the text is splitted
- * across multiple different HTML elements which cannot be searched by normal
+ * across different HTML elements which cannot be searched by normal
  * *ByText methods. It returns a function that can be passed to the testing
  * library's *ByText methods.
  * @param textToMatch The string that needs to be matched
@@ -53,4 +53,22 @@ export const getByTextContent = (textToMatch: string) => (
   )
 
   return nodeHasText && childrenDontHaveText
+}
+
+interface CreateQueryClientResponse {
+  queryClient: QueryClient
+  queryCache: QueryCache
+}
+
+export const createQueryClient = (): CreateQueryClientResponse => {
+  const queryCache = new QueryCache()
+  const queryClient = new QueryClient({
+    queryCache,
+    defaultOptions: {
+      queries: {
+        staleTime: 0,
+      },
+    },
+  })
+  return { queryClient, queryCache }
 }

--- a/src/devtools/tests/utils.tsx
+++ b/src/devtools/tests/utils.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { ReactQueryDevtools } from '../'
+
+import { QueryClient, QueryClientProvider } from '../..'
+
+export function renderWithClient(
+  client: QueryClient,
+  ui: React.ReactElement,
+  devtoolsOptions?: Parameters<typeof ReactQueryDevtools>[number]
+) {
+  const { rerender, ...result } = render(
+    <QueryClientProvider client={client}>
+      <ReactQueryDevtools initialIsOpen={false} {...devtoolsOptions} />
+      {ui}
+    </QueryClientProvider>
+  )
+  return {
+    ...result,
+    rerender: (rerenderUi: React.ReactElement) =>
+      rerender(
+        <QueryClientProvider client={client}>
+          <ReactQueryDevtools {...devtoolsOptions} />
+          {rerenderUi}
+        </QueryClientProvider>
+      ),
+  }
+}
+
+export function sleep(timeout: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout)
+  })
+}

--- a/src/devtools/tests/utils.tsx
+++ b/src/devtools/tests/utils.tsx
@@ -41,7 +41,10 @@ export function sleep(timeout: number): Promise<void> {
  * @param textToMatch The string that needs to be matched
  * @reference https://stackoverflow.com/a/56859650/8252081
  */
-export const getByTextContent = (textToMatch: string) => (content: string, node: HTMLElement): boolean => {
+export const getByTextContent = (textToMatch: string) => (
+  _content: string,
+  node: HTMLElement
+): boolean => {
   const hasText = (currentNode: HTMLElement) =>
     currentNode.textContent === textToMatch
   const nodeHasText = hasText(node)

--- a/src/devtools/tests/utils.tsx
+++ b/src/devtools/tests/utils.tsx
@@ -11,7 +11,7 @@ export function renderWithClient(
 ) {
   const { rerender, ...result } = render(
     <QueryClientProvider client={client}>
-      <ReactQueryDevtools initialIsOpen={false} {...devtoolsOptions} />
+      <ReactQueryDevtools {...devtoolsOptions} />
       {ui}
     </QueryClientProvider>
   )
@@ -31,4 +31,23 @@ export function sleep(timeout: number): Promise<void> {
   return new Promise(resolve => {
     setTimeout(resolve, timeout)
   })
+}
+
+/**
+ * This method is useful for matching by text content when the text is splitted
+ * across multiple different HTML elements which cannot be searched by normal
+ * *ByText methods. It returns a function that can be passed to the testing
+ * library's *ByText methods.
+ * @param textToMatch The string that needs to be matched
+ * @reference https://stackoverflow.com/a/56859650/8252081
+ */
+export const getByTextContent = (textToMatch: string) => (content: string, node: HTMLElement): boolean => {
+  const hasText = (currentNode: HTMLElement) =>
+    currentNode.textContent === textToMatch
+  const nodeHasText = hasText(node)
+  const childrenDontHaveText = Array.from(node.children).every(
+    child => !hasText(child as HTMLElement)
+  )
+
+  return nodeHasText && childrenDontHaveText
 }


### PR DESCRIPTION
- ✅.  Added the following tests for devtools (except query details explorer)
    - Opening and closing the devtools panel
    - Displaying the correct states for queries
    - Displaying all the query hash in the rows and opening the query details explorer upon clicking it
    - Searching the queries
    - Sorting the queries via different sorting filters available
- ♿️    Added accessibility labels to buttons and inputs, which not only helped in writing good tests but also improved the overall accessibility of devtools
- 🐛.  Fixed a bug that sorted queries incorrectly. While adding the test cases for sorting queries, I found that the sorting was not working as expected because of an incorrect key name being used (`updatedAt` instead of `dataUpdatedAt`)

Fixes #2371 