### PR TITLE
docs: Update testing with disabled retries

### DIFF
--- a/docs/src/pages/guides/testing.md
+++ b/docs/src/pages/guides/testing.md
@@ -46,6 +46,28 @@ Note that we provide a custom wrapper that builds the `QueryClient` and `QueryCl
 
 It is possible to write this wrapper only once, but if so we need to ensure that the `QueryClient` gets cleared before every test, and that tests don't run in parallel otherwise one test will influence the results of others.
 
+## Turn off retries
+
+The library defaults to three retries with exponential backoff, which means that your tests are likely to timeout if you want to test an erroneous query. The easiest way to turn retries off is via the QueryClientProvider. Let's extend the above example:
+
+```
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // ✅ turns retries off
+      retry: false,
+    },
+  },
+})
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+```
+
+This will set the defaults for all queries in the component tree to "no retries". It is important to know that this will only work if your actual useQuery has no explicit retries set. If you have a query that wants 5 retries, this will still take precedence, because defaults are only taken as a fallback.
+
 ## Testing Network Calls
 
 The primary use for React Query is to cache network requests, so it's important that we can test our code is making the correct network requests in the first place.


### PR DESCRIPTION
When testing my app with jest + enzyme I had a lot of problems trying to resolve the `useQuery` api call, then I found on [this blog post](https://tkdodo.eu/blog/testing-react-query#turn-off-retries) explaining that disabling the default retries can make things easier, and that indeed worked for me.

So I just took a piece of the doc written on that blog post (because it was already well written and clear) and added it to the official docs, I really think that'll help out new react-query users test their apps if they come across that issue 🤘 