### PR TITLE
fix(MutationOptions): improve the type of onMutate

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -481,7 +481,7 @@ export interface MutationOptions<
   variables?: TVariables
   onMutate?: (
     variables: TVariables
-  ) => Promise<TContext> | Promise<undefined> | TContext | undefined
+  ) => Promise<TContext | undefined> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -77,7 +77,7 @@ export interface UseMutationOptions<
   mutationKey?: MutationKey
   onMutate?: (
     variables: TVariables
-  ) => Promise<TContext> | Promise<undefined> | TContext | undefined
+  ) => Promise<TContext | undefined> | TContext | undefined
   onSuccess?: (
     data: TData,
     variables: TVariables,


### PR DESCRIPTION
Hey maintainers,

As I can see, `Promise<A> | Promise<B>` is stricter than `Promise<A | B>` and to the point that it won't work with async functions.

<img width="1026" alt="Screen Shot 2021-07-23 at 21 11 48" src="https://user-images.githubusercontent.com/18229698/126794615-8801c191-e11d-4088-ab86-9e90c17d8fa8.png">

In the case of `onMutate`, because we currently define its type as
```ts
onMutate?: (variables: TVariables) => Promise<TContext> | Promise<undefined> | TContext | undefined;
```
,  when we set an async function to it we'll receive a type error but it's very obscure and appears at another place.

<img width="894" alt="Screen Shot 2021-07-23 at 21 09 10" src="https://user-images.githubusercontent.com/18229698/126796926-86b4e31a-18eb-4ead-a47c-bbc878ed88f2.png">

So in this PR, I set the return type of `onMutate` to `Promise<TContext | undefined>` instead of `Promise<TContext> | Promise<undefined>` to relax it to make it work with async functions.