### PR TITLE
feat(hydration): move hydration utilities to core, keeping old exports

### DIFF
--- a/src/core/hydration.ts
+++ b/src/core/hydration.ts
@@ -1,12 +1,12 @@
-import type { QueryClient } from '../core/queryClient'
-import type { Query, QueryState } from '../core/query'
+import type { QueryClient } from './queryClient'
+import type { Query, QueryState } from './query'
 import type {
   MutationKey,
   MutationOptions,
   QueryKey,
   QueryOptions,
-} from '../core/types'
-import type { Mutation, MutationState } from '../core/mutation'
+} from './types'
+import type { Mutation, MutationState } from './mutation'
 
 // TYPES
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,8 +12,16 @@ export { focusManager } from './focusManager'
 export { onlineManager } from './onlineManager'
 export { hashQueryKey, isError } from './utils'
 export { isCancelledError } from './retryer'
+export { dehydrate, hydrate } from './hydration'
 
 // Types
 export * from './types'
 export type { Query } from './query'
 export type { Logger } from './logger'
+export type {
+  DehydrateOptions,
+  DehydratedState,
+  HydrateOptions,
+  ShouldDehydrateMutationFunction,
+  ShouldDehydrateQueryFunction,
+} from './hydration'

--- a/src/core/tests/hydration.test.tsx
+++ b/src/core/tests/hydration.test.tsx
@@ -1,5 +1,6 @@
 import { mockNavigatorOnLine, sleep } from '../../react/tests/utils'
-import { QueryCache, QueryClient } from '../..'
+import { QueryCache } from '../queryCache'
+import { QueryClient } from '../queryClient'
 import { dehydrate, hydrate } from '../hydration'
 
 async function fetchData<TData>(value: TData, ms?: number): Promise<TData> {

--- a/src/hydration/index.ts
+++ b/src/hydration/index.ts
@@ -1,4 +1,4 @@
-export { dehydrate, hydrate } from '../core/hydration'
+export { dehydrate, hydrate } from 'react-query'
 export { useHydrate, Hydrate } from './react'
 
 // Types

--- a/src/hydration/index.ts
+++ b/src/hydration/index.ts
@@ -1,5 +1,8 @@
-export { dehydrate, hydrate } from 'react-query'
-export { useHydrate, Hydrate } from './react'
+// This package once contained these functions, but they have now been moved
+// into the core and react packages.
+// They are re-exported here to avoid a breaking change, but this package
+// should be considered deprecated and removed in a future major version.
+export { dehydrate, hydrate, useHydrate, Hydrate } from 'react-query'
 
 // Types
 export type {
@@ -9,4 +12,4 @@ export type {
   ShouldDehydrateMutationFunction,
   ShouldDehydrateQueryFunction,
 } from '../core/hydration'
-export type { HydrateProps } from './react'
+export type { HydrateProps } from '../react/Hydrate'

--- a/src/hydration/index.ts
+++ b/src/hydration/index.ts
@@ -1,4 +1,4 @@
-export { dehydrate, hydrate } from './hydration'
+export { dehydrate, hydrate } from '../core/hydration'
 export { useHydrate, Hydrate } from './react'
 
 // Types
@@ -6,6 +6,7 @@ export type {
   DehydrateOptions,
   DehydratedState,
   HydrateOptions,
+  ShouldDehydrateMutationFunction,
   ShouldDehydrateQueryFunction,
-} from './hydration'
+} from '../core/hydration'
 export type { HydrateProps } from './react'

--- a/src/hydration/react.tsx
+++ b/src/hydration/react.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { useQueryClient } from 'react-query'
-import { hydrate, HydrateOptions } from './hydration'
+import { hydrate, HydrateOptions } from '../core/hydration'
 
 export function useHydrate(state: unknown, options?: HydrateOptions) {
   const queryClient = useQueryClient()

--- a/src/hydration/react.tsx
+++ b/src/hydration/react.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
-import { useQueryClient } from 'react-query'
-import { hydrate, HydrateOptions } from '../core/hydration'
+import { useQueryClient, hydrate, HydrateOptions } from 'react-query'
 
 export function useHydrate(state: unknown, options?: HydrateOptions) {
   const queryClient = useQueryClient()

--- a/src/react/Hydrate.tsx
+++ b/src/react/Hydrate.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { useQueryClient, hydrate, HydrateOptions } from 'react-query'
+import { hydrate, HydrateOptions } from '../core'
+import { useQueryClient } from './QueryClientProvider'
 
 export function useHydrate(state: unknown, options?: HydrateOptions) {
   const queryClient = useQueryClient()

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -13,8 +13,10 @@ export { useMutation } from './useMutation'
 export { useQuery } from './useQuery'
 export { useQueries } from './useQueries'
 export { useInfiniteQuery } from './useInfiniteQuery'
+export { useHydrate, Hydrate } from './Hydrate'
 
 // Types
 export * from './types'
 export type { QueryClientProviderProps } from './QueryClientProvider'
 export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
+export type { HydrateProps } from './Hydrate'

--- a/src/react/tests/Hydrate.test.tsx
+++ b/src/react/tests/Hydrate.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import { QueryClient, QueryClientProvider, QueryCache, useQuery } from '../..'
-import { dehydrate, useHydrate, Hydrate } from '../'
-import { sleep } from '../../react/tests/utils'
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+  useQuery,
+  dehydrate,
+  useHydrate,
+  Hydrate,
+} from '../..'
+import { sleep } from './utils'
 
 describe('React hydration', () => {
   const fetchData: (value: string) => Promise<string> = value =>

--- a/src/react/tests/ssr-hydration.test.tsx
+++ b/src/react/tests/ssr-hydration.test.tsx
@@ -2,10 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
 
-import { useQuery, QueryClient, QueryClientProvider, QueryCache } from '../..'
-import { dehydrate, hydrate } from '../'
+import {
+  useQuery,
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+  dehydrate,
+  hydrate,
+} from '../..'
 import * as utils from '../../core/utils'
-import { mockConsoleError, sleep } from '../../react/tests/utils'
+import { mockConsoleError, sleep } from './utils'
 
 // This monkey-patches the isServer-value from utils,
 // so that we can pretend to be in a server environment


### PR DESCRIPTION
Following: https://github.com/tannerlinsley/react-query/discussions/2370

Move hydration utilities to the core.
Retain old exports for backward compatibility.
Export additional type that was missed before.