### PR TITLE
fix: example of axios cancelling request 

### DIFF
--- a/docs/src/pages/guides/query-cancellation.md
+++ b/docs/src/pages/guides/query-cancellation.md
@@ -14,10 +14,11 @@ But don't worry! If your queries are high-bandwidth or potentially very expensiv
 ## Using `axios`
 
 ```js
-import { CancelToken } from 'axios'
+import axios from 'axios'
 
 const query = useQuery('todos', () => {
   // Create a new CancelToken source for this request
+  const CancelToken = axios.CancelToken
   const source = CancelToken.source()
 
   const promise = axios.get('/todos', {


### PR DESCRIPTION
Importing `CancelToken` imports type. The propose change matches [recent docs for cancellation of axios here](https://github.com/axios/axios#cancellation).