### PR TITLE
Support the ability to provide a context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#00da63", // change this color!
-    "titleBar.inactiveBackground": "#00da63", // change this color!
-    "titleBar.activeForeground": "#ffffff", // change this color!
-    "titleBar.inactiveForeground": "#ffffff" // change this color!
-  }
-}

--- a/docs/src/pages/devtools.md
+++ b/docs/src/pages/devtools.md
@@ -18,6 +18,7 @@ import { ReactQueryDevtools } from 'react-query/devtools'
 ```
 
 By default, React Query Devtools are only included in bundles when `process.env.NODE_ENV === 'development'`, so you don't need to worry about excluding them during a production build.
+
 ## Floating Mode
 
 Floating Mode will mount the devtools as a fixed, floating element in your app and provide a toggle in the corner of the screen to show and hide the devtools. This toggle state will be stored and remembered in localStorage across reloads.
@@ -50,6 +51,8 @@ function App() {
 - `position?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
   - Defaults to `bottom-left`
   - The position of the React Query logo to open and close the devtools panel
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 ## Embedded Mode
 

--- a/docs/src/pages/devtools.md
+++ b/docs/src/pages/devtools.md
@@ -52,7 +52,7 @@ function App() {
   - Defaults to `bottom-left`
   - The position of the React Query logo to open and close the devtools panel
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 ## Embedded Mode
 

--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -332,3 +332,90 @@ When using the [functional updater form of setQueryData](../reference/QueryClien
    (previousTodo) => previousTodo ? { ...previousTodo, done: true } : undefined
 )
  ```
+
+ ### Custom Contexts for Multiple Providers
+
+Custom contexts can now be specified to pair hooks with their matching `Provider`. This is critical when there may be multiple React Query `Provider` instances in the component tree and you need to ensure your hook uses the correct `Provider` instance.
+
+An example:
+
+1) Create a data package.
+
+```tsx
+// Our first data package: @my-scope/container-data
+
+const context = React.createContext<QueryClient | undefined>();
+const queryCache = new QueryCache()
+const queryClient = new QueryClient({ queryCache, context })
+
+
+export const useUser = () => {
+  return useQuery(USER_KEY, USER_FETCHER, {
+    context,
+  })
+}
+
+export const ContainerDataProvider: React.FC = ({ children }) => {
+  return (
+    <QueryClientProvider client={queryClient} context={context}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+```
+
+2) Create a second data package.
+
+```tsx
+// Our second data package: @my-scope/my-component-data
+
+const context = React.createContext<QueryClient | undefined>();
+const queryCache = new QueryCache()
+const queryClient = new QueryClient({ queryCache, context })
+
+
+export const useItems = () => {
+  return useQuery(ITEMS_KEY, ITEMS_FETCHER, {
+    context,
+  })
+}
+
+export const MyComponentDataProvider: React.FC = ({ children }) => {
+  return (
+    <QueryClientProvider client={queryClient} context={context}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+```
+
+3) Use these two data packages in your application.
+
+```tsx
+// Our application
+
+import { ContainerDataProvider, useUser } from "@my-scope/container-data";
+import { AppDataProvider } from "@my-scope/app-data";
+import { MyComponentDataProvider, useItems } from "@my-scope/my-component-data";
+
+<ContainerDataProvider> // <-- Provides container data (like "user") using its own React Query provider
+  ...
+  <AppDataProvider> // <-- Provides app data using its own React Query provider (unused in this example)
+    ...
+      <MyComponentDataProvider> // <-- Provides component data (like "items") using its own React Query provider
+        <MyComponent />
+      </MyComponentDataProvider>
+    ...
+  </AppDataProvider>
+  ...
+</ContainerDataProvider>
+
+// Example of hooks provided by the "DataProvider" components above:
+const MyComponent = () => {
+  const user = useUser(); // <-- Uses the context specified in ContainerDataProvider.
+  const items = useItems(); // <-- Uses the context specified in MyComponentDataProvider
+  ...
+}
+```

--- a/docs/src/pages/reference/QueryClientProvider.md
+++ b/docs/src/pages/reference/QueryClientProvider.md
@@ -14,6 +14,7 @@ function App() {
   return <QueryClientProvider client={queryClient}>...</QueryClientProvider>
 }
 ```
+
 **Options**
 
 - `client: QueryClient`
@@ -21,4 +22,6 @@ function App() {
   - the QueryClient instance to provide
 - `contextSharing: boolean`
   - defaults to `false`
-  - Set this to `true` to enable context sharing, which will share the first and at least one instance of the context across the window  to ensure that if React Query is used across  different bundles or microfrontends they will  all use the same **instance** of context, regardless of module scoping.
+  - Set this to `true` to enable context sharing, which will share the first and at least one instance of the context across the window to ensure that if React Query is used across different bundles or microfrontends they will all use the same **instance** of context, regardless of module scoping.
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.

--- a/docs/src/pages/reference/QueryClientProvider.md
+++ b/docs/src/pages/reference/QueryClientProvider.md
@@ -24,4 +24,4 @@ function App() {
   - defaults to `false`
   - Set this to `true` to enable context sharing, which will share the first and at least one instance of the context across the window to ensure that if React Query is used across different bundles or microfrontends they will all use the same **instance** of context, regardless of module scoping.
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.

--- a/docs/src/pages/reference/hydration.md
+++ b/docs/src/pages/reference/hydration.md
@@ -84,6 +84,8 @@ hydrate(queryClient, dehydratedState, options)
     - Optional
     - `mutations: MutationOptions` The default mutation options to use for the hydrated mutations.
     - `queries: QueryOptions` The default query options to use for the hydrated queries.
+  - `context?: React.Context<QueryClient | undefined>`
+    - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 ### Limitations
 
@@ -108,6 +110,8 @@ useHydrate(dehydratedState, options)
   - Optional
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
+  - `context?: React.Context<QueryClient | undefined>`
+    - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 ## `Hydrate`
 
@@ -129,3 +133,5 @@ function App() {
   - Optional
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
+  - `context?: React.Context<QueryClient | undefined>`
+    - Use this to use a custom React Query context. Otherwise, the default will be used.

--- a/docs/src/pages/reference/hydration.md
+++ b/docs/src/pages/reference/hydration.md
@@ -85,7 +85,7 @@ hydrate(queryClient, dehydratedState, options)
     - `mutations: MutationOptions` The default mutation options to use for the hydrated mutations.
     - `queries: QueryOptions` The default query options to use for the hydrated queries.
   - `context?: React.Context<QueryClient | undefined>`
-    - Use this to use a custom React Query context. Otherwise, the default will be used.
+    - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 ### Limitations
 
@@ -111,7 +111,7 @@ useHydrate(dehydratedState, options)
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
   - `context?: React.Context<QueryClient | undefined>`
-    - Use this to use a custom React Query context. Otherwise, the default will be used.
+    - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 ## `Hydrate`
 
@@ -134,4 +134,4 @@ function App() {
   - `defaultOptions: QueryOptions`
     - The default query options to use for the hydrated queries.
   - `context?: React.Context<QueryClient | undefined>`
-    - Use this to use a custom React Query context. Otherwise, the default will be used.
+    - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.

--- a/docs/src/pages/reference/useIsFetching.md
+++ b/docs/src/pages/reference/useIsFetching.md
@@ -17,6 +17,8 @@ const isFetchingPosts = useIsFetching(['posts'])
 
 - `queryKey?: QueryKey`: [Query Keys](../guides/query-keys)
 - `filters?: QueryFilters`: [Query Filters](../guides/filters#query-filters)
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useIsFetching.md
+++ b/docs/src/pages/reference/useIsFetching.md
@@ -18,7 +18,7 @@ const isFetchingPosts = useIsFetching(['posts'])
 - `queryKey?: QueryKey`: [Query Keys](../guides/query-keys)
 - `filters?: QueryFilters`: [Query Filters](../guides/filters#query-filters)
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useIsMutating.md
+++ b/docs/src/pages/reference/useIsMutating.md
@@ -17,6 +17,8 @@ const isMutatingPosts = useIsMutating(['posts'])
 
 - `mutationKey?: string | unknown[]`
 - `filters?: MutationFilters`: [Mutation Filters](../guides/filters#mutation-filters)
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useIsMutating.md
+++ b/docs/src/pages/reference/useIsMutating.md
@@ -18,7 +18,7 @@ const isMutatingPosts = useIsMutating(['posts'])
 - `mutationKey?: string | unknown[]`
 - `filters?: MutationFilters`: [Mutation Filters](../guides/filters#mutation-filters)
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -87,6 +87,8 @@ mutate(variables, {
 - `meta: Record<string, unknown>`
   - Optional
   - If set, stores additional information on the mutation cache entry that can be used as needed. It will be accessible wherever the `mutation` is available (eg. `onError`, `onSuccess` functions of the `MutationCache`).
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -88,7 +88,7 @@ mutate(variables, {
   - Optional
   - If set, stores additional information on the mutation cache entry that can be used as needed. It will be accessible wherever the `mutation` is available (eg. `onError`, `onSuccess` functions of the `MutationCache`).
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useQueries.md
+++ b/docs/src/pages/reference/useQueries.md
@@ -16,7 +16,10 @@ const results = useQueries({
 
 **Options**
 
-The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](/reference/useQuery).
+The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](/reference/useQuery) (excluding the `context` option).
+
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useQueries.md
+++ b/docs/src/pages/reference/useQueries.md
@@ -19,7 +19,7 @@ const results = useQueries({
 The `useQueries` hook accepts an options object with a **queries** key whose value is an array with query option objects identical to the [`useQuery` hook](/reference/useQuery) (excluding the `context` option).
 
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -185,6 +185,8 @@ const result = useQuery({
 - `meta: Record<string, unknown>`
   - Optional
   - If set, stores additional information on the query cache entry that can be used as needed. It will be accessible wherever the `query` is available, and is also part of the `QueryFunctionContext` provided to the `queryFn`.
+- `context?: React.Context<QueryClient | undefined>`
+  - Use this to use a custom React Query context. Otherwise, the default will be used.
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -186,7 +186,7 @@ const result = useQuery({
   - Optional
   - If set, stores additional information on the query cache entry that can be used as needed. It will be accessible wherever the `query` is available, and is also part of the `QueryFunctionContext` provided to the `queryFn`.
 - `context?: React.Context<QueryClient | undefined>`
-  - Use this to use a custom React Query context. Otherwise, the default will be used.
+  - Use this to use a custom React Query context. Otherwise, `defaultContext` will be used.
 
 **Returns**
 

--- a/src/core/hydration.ts
+++ b/src/core/hydration.ts
@@ -1,3 +1,4 @@
+import type { ContextOptions } from '../reactjs/types'
 import type { QueryClient } from './queryClient'
 import type { Query, QueryState } from './query'
 import type {
@@ -17,7 +18,7 @@ export interface DehydrateOptions {
   shouldDehydrateQuery?: ShouldDehydrateQueryFunction
 }
 
-export interface HydrateOptions {
+export interface HydrateOptions extends ContextOptions {
   defaultOptions?: {
     queries?: QueryOptions
     mutations?: MutationOptions

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -154,11 +154,17 @@ export function parseFilterArgs<
     : [arg1 || {}, arg2]) as [TFilters, TOptions]
 }
 
-export function parseMutationFilterArgs(
-  arg1?: QueryKey | MutationFilters,
-  arg2?: MutationFilters
-): MutationFilters | undefined {
-  return isQueryKey(arg1) ? { ...arg2, mutationKey: arg1 } : arg1
+export function parseMutationFilterArgs<
+  TFilters extends MutationFilters,
+  TOptions = unknown
+>(
+  arg1?: QueryKey | TFilters,
+  arg2?: TFilters | TOptions,
+  arg3?: TOptions
+): [TFilters, TOptions | undefined] {
+  return (isQueryKey(arg1)
+    ? [{ ...arg2, mutationKey: arg1 }, arg3]
+    : [arg1 || {}, arg2]) as [TFilters, TOptions]
 }
 
 export function matchQuery(

--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 
-import { Query, useQueryClient, onlineManager } from 'react-query'
+import {
+  Query,
+  ContextOptions,
+  useQueryClient,
+  onlineManager,
+} from 'react-query'
 import { matchSorter } from 'match-sorter'
 import useLocalStorage from './useLocalStorage'
 import { useIsMounted, useSafeState } from './utils'
@@ -21,7 +26,7 @@ import Explorer from './Explorer'
 import Logo from './Logo'
 import { noop } from '../core/utils'
 
-interface DevtoolsOptions {
+interface DevtoolsOptions extends ContextOptions {
   /**
    * Set this true if you want the dev tools to default to being open
    */
@@ -60,7 +65,7 @@ interface DevtoolsOptions {
   containerElement?: string | any
 }
 
-interface DevtoolsPanelOptions {
+interface DevtoolsPanelOptions extends ContextOptions {
   /**
    * The standard React style object used to style a component with inline styles
    */
@@ -92,6 +97,7 @@ export function ReactQueryDevtools({
   toggleButtonProps = {},
   position = 'bottom-left',
   containerElement: Container = 'aside',
+  context,
 }: DevtoolsOptions): React.ReactElement | null {
   const rootRef = React.useRef<HTMLDivElement>(null)
   const panelRef = React.useRef<HTMLDivElement>(null)
@@ -229,6 +235,7 @@ export function ReactQueryDevtools({
       <ThemeProvider theme={theme}>
         <ReactQueryDevtoolsPanel
           ref={panelRef as any}
+          context={context}
           {...otherPanelProps}
           style={{
             position: 'fixed',
@@ -381,9 +388,15 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
   HTMLDivElement,
   DevtoolsPanelOptions
 >(function ReactQueryDevtoolsPanel(props, ref): React.ReactElement {
-  const { isOpen = true, setIsOpen, handleDragStart, ...panelProps } = props
+  const {
+    isOpen = true,
+    setIsOpen,
+    handleDragStart,
+    context,
+    ...panelProps
+  } = props
 
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient({ context })
   const queryCache = queryClient.getQueryCache()
 
   const [sort, setSort] = useLocalStorage(

--- a/src/devtools/tests/devtools.test.tsx
+++ b/src/devtools/tests/devtools.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 import {
   fireEvent,
   screen,
@@ -7,7 +8,7 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { useQuery } from '../..'
+import { useQuery, QueryClient } from '../..'
 import {
   getByTextContent,
   renderWithClient,
@@ -75,6 +76,39 @@ describe('ReactQueryDevtools', () => {
     await screen.findByRole('button', { name: /open react query devtools/i })
 
     expect(onCloseClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should be able to drag devtools without error', async () => {
+    const { queryClient } = createQueryClient()
+
+    function Page() {
+      const { data = 'default' } = useQuery(['check'], async () => {
+        await sleep(10)
+        return 'test'
+      })
+
+      return (
+        <div>
+          <h1>{data}</h1>
+        </div>
+      )
+    }
+
+    const result = renderWithClient(queryClient, <Page />, {
+      initialIsOpen: false,
+    })
+
+    const draggableElement = result.container
+      .querySelector('#ReactQueryDevtoolsPanel')
+      ?.querySelector('div')
+
+    if (!draggableElement) {
+      throw new Error('Could not find the draggable element')
+    }
+
+    await act(async () => {
+      fireEvent.mouseDown(draggableElement)
+    })
   })
 
   it('should display the correct query states', async () => {
@@ -469,5 +503,101 @@ describe('ReactQueryDevtools', () => {
     expect(queries[0]?.textContent).toEqual(query1Hash)
     expect(queries[1]?.textContent).toEqual(query2Hash)
     expect(queries[2]?.textContent).toEqual(query3Hash)
+  })
+
+  describe('with custom context', () => {
+    it('should render without error when the custom context aligns', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+      const { queryClient } = createQueryClient()
+
+      function Page() {
+        const { data = 'default' } = useQuery(['check'], async () => 'test', {
+          context,
+        })
+
+        return (
+          <div>
+            <h1>{data}</h1>
+          </div>
+        )
+      }
+
+      renderWithClient(queryClient, <Page />, {
+        initialIsOpen: false,
+        context,
+      })
+
+      await screen.findByRole('button', { name: /open react query devtools/i })
+    })
+
+    it('should render with error when the custom context is not passed to useQuery', async () => {
+      const consoleErrorMock = jest.spyOn(console, 'error')
+      consoleErrorMock.mockImplementation(() => undefined)
+
+      const context = React.createContext<QueryClient | undefined>(undefined)
+      const { queryClient } = createQueryClient()
+
+      function Page() {
+        const { data = 'default' } = useQuery(['check'], async () => 'test', {
+          useErrorBoundary: true,
+        })
+
+        return (
+          <div>
+            <h1>{data}</h1>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(
+        queryClient,
+        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+          <Page />
+        </ErrorBoundary>,
+        {
+          initialIsOpen: false,
+          context,
+        }
+      )
+
+      await waitFor(() => rendered.getByText('error boundary'))
+
+      consoleErrorMock.mockRestore()
+    })
+
+    it('should render with error when the custom context is not passed to ReactQueryDevtools', async () => {
+      const consoleErrorMock = jest.spyOn(console, 'error')
+      consoleErrorMock.mockImplementation(() => undefined)
+
+      const context = React.createContext<QueryClient | undefined>(undefined)
+      const { queryClient } = createQueryClient()
+
+      function Page() {
+        const { data = 'default' } = useQuery(['check'], async () => 'test', {
+          useErrorBoundary: true,
+          context,
+        })
+
+        return (
+          <div>
+            <h1>{data}</h1>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(
+        queryClient,
+        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+          <Page />
+        </ErrorBoundary>,
+        {
+          initialIsOpen: false,
+        }
+      )
+
+      await waitFor(() => rendered.getByText('error boundary'))
+
+      consoleErrorMock.mockRestore()
+    })
   })
 })

--- a/src/devtools/tests/utils.tsx
+++ b/src/devtools/tests/utils.tsx
@@ -7,10 +7,10 @@ import { QueryClient, QueryClientProvider, QueryCache } from '../..'
 export function renderWithClient(
   client: QueryClient,
   ui: React.ReactElement,
-  devtoolsOptions?: Parameters<typeof ReactQueryDevtools>[number]
+  devtoolsOptions: Parameters<typeof ReactQueryDevtools>[number] = {}
 ) {
   const { rerender, ...result } = render(
-    <QueryClientProvider client={client}>
+    <QueryClientProvider client={client} context={devtoolsOptions.context}>
       <ReactQueryDevtools {...devtoolsOptions} />
       {ui}
     </QueryClientProvider>
@@ -19,7 +19,7 @@ export function renderWithClient(
     ...result,
     rerender: (rerenderUi: React.ReactElement) =>
       rerender(
-        <QueryClientProvider client={client}>
+        <QueryClientProvider client={client} context={devtoolsOptions.context}>
           <ReactQueryDevtools {...devtoolsOptions} />
           {rerenderUi}
         </QueryClientProvider>

--- a/src/reactjs/Hydrate.tsx
+++ b/src/reactjs/Hydrate.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import { hydrate, HydrateOptions } from '../core'
 import { useQueryClient } from './QueryClientProvider'
 
-export function useHydrate(state: unknown, options?: HydrateOptions) {
-  const queryClient = useQueryClient()
+export function useHydrate(state: unknown, options: HydrateOptions = {}) {
+  const queryClient = useQueryClient({ context: options.context })
 
   const optionsRef = React.useRef(options)
   optionsRef.current = options

--- a/src/reactjs/QueryClientProvider.tsx
+++ b/src/reactjs/QueryClientProvider.tsx
@@ -9,7 +9,9 @@ declare global {
   }
 }
 
-const defaultContext = React.createContext<QueryClient | undefined>(undefined)
+export const defaultContext = React.createContext<QueryClient | undefined>(
+  undefined
+)
 const QueryClientSharingContext = React.createContext<boolean>(false)
 
 // If we are given a context, we will use it.

--- a/src/reactjs/QueryClientProvider.tsx
+++ b/src/reactjs/QueryClientProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { QueryClient } from '../core'
+import { ContextOptions } from '../reactjs/types'
 
 declare global {
   interface Window {
@@ -11,13 +12,20 @@ declare global {
 const defaultContext = React.createContext<QueryClient | undefined>(undefined)
 const QueryClientSharingContext = React.createContext<boolean>(false)
 
-// if contextSharing is on, we share the first and at least one
+// If we are given a context, we will use it.
+// Otherwise, if contextSharing is on, we share the first and at least one
 // instance of the context across the window
 // to ensure that if React Query is used across
 // different bundles or microfrontends they will
 // all use the same **instance** of context, regardless
 // of module scoping.
-function getQueryClientContext(contextSharing: boolean) {
+function getQueryClientContext(
+  context: React.Context<QueryClient | undefined> | undefined,
+  contextSharing: boolean
+) {
+  if (context) {
+    return context
+  }
   if (contextSharing && typeof window !== 'undefined') {
     if (!window.ReactQueryClientContext) {
       window.ReactQueryClientContext = defaultContext
@@ -29,9 +37,9 @@ function getQueryClientContext(contextSharing: boolean) {
   return defaultContext
 }
 
-export const useQueryClient = () => {
+export const useQueryClient = ({ context }: ContextOptions = {}) => {
   const queryClient = React.useContext(
-    getQueryClientContext(React.useContext(QueryClientSharingContext))
+    getQueryClientContext(context, React.useContext(QueryClientSharingContext))
   )
 
   if (!queryClient) {
@@ -41,15 +49,26 @@ export const useQueryClient = () => {
   return queryClient
 }
 
-export interface QueryClientProviderProps {
+type QueryClientProviderPropsBase = {
   client: QueryClient
-  contextSharing?: boolean
 }
+type QueryClientProviderPropsWithContext = ContextOptions & {
+  contextSharing?: never
+} & QueryClientProviderPropsBase
+type QueryClientProviderPropsWithContextSharing = {
+  context?: never
+  contextSharing?: boolean
+} & QueryClientProviderPropsBase
+
+export type QueryClientProviderProps =
+  | QueryClientProviderPropsWithContext
+  | QueryClientProviderPropsWithContextSharing
 
 export const QueryClientProvider: React.FC<QueryClientProviderProps> = ({
   client,
-  contextSharing = false,
   children,
+  context,
+  contextSharing = false,
 }) => {
   React.useEffect(() => {
     client.mount()
@@ -58,10 +77,10 @@ export const QueryClientProvider: React.FC<QueryClientProviderProps> = ({
     }
   }, [client])
 
-  const Context = getQueryClientContext(contextSharing)
+  const Context = getQueryClientContext(context, contextSharing)
 
   return (
-    <QueryClientSharingContext.Provider value={contextSharing}>
+    <QueryClientSharingContext.Provider value={!context && contextSharing}>
       <Context.Provider value={client}>{children}</Context.Provider>
     </QueryClientSharingContext.Provider>
   )

--- a/src/reactjs/index.ts
+++ b/src/reactjs/index.ts
@@ -1,7 +1,11 @@
 // Side effects
 import './setBatchUpdatesFn'
 
-export { QueryClientProvider, useQueryClient } from './QueryClientProvider'
+export {
+  defaultContext,
+  QueryClientProvider,
+  useQueryClient,
+} from './QueryClientProvider'
 export {
   QueryErrorResetBoundary,
   useQueryErrorResetBoundary,

--- a/src/reactjs/tests/Hydrate.test.tsx
+++ b/src/reactjs/tests/Hydrate.test.tsx
@@ -71,13 +71,9 @@ describe('React hydration', () => {
 
       function Page() {
         useHydrate(dehydratedState, { context })
-        const { data } = useQuery(
-          ['string'],
-          () => dataQuery(['stringCached']),
-          {
-            context,
-          }
-        )
+        const { data } = useQuery(['string'], () => dataQuery(['string']), {
+          context,
+        })
         return (
           <div>
             <h1>{data}</h1>

--- a/src/reactjs/tests/Hydrate.test.tsx
+++ b/src/reactjs/tests/Hydrate.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import {
+  QueryClient,
   QueryClientProvider,
   QueryCache,
   useQuery,
@@ -21,7 +22,9 @@ describe('React hydration', () => {
   beforeAll(async () => {
     const queryCache = new QueryCache()
     const queryClient = createQueryClient({ queryCache })
-    await queryClient.prefetchQuery(['string'], () => dataQuery(['string']))
+    await queryClient.prefetchQuery(['string'], () =>
+      dataQuery(['stringCached'])
+    )
     const dehydrated = dehydrate(queryClient)
     stringifiedState = JSON.stringify(dehydrated)
     queryClient.clear()
@@ -49,9 +52,53 @@ describe('React hydration', () => {
         </QueryClientProvider>
       )
 
+      rendered.getByText('stringCached')
       await sleep(10)
       rendered.getByText('string')
       queryClient.clear()
+    })
+
+    test('should hydrate queries to the cache on custom context', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+
+      const queryCacheOuter = new QueryCache()
+      const queryCacheInner = new QueryCache()
+
+      const queryClientInner = new QueryClient({ queryCache: queryCacheInner })
+      const queryClientOuter = new QueryClient({ queryCache: queryCacheOuter })
+
+      const dehydratedState = JSON.parse(stringifiedState)
+
+      function Page() {
+        useHydrate(dehydratedState, { context })
+        const { data } = useQuery(
+          ['string'],
+          () => dataQuery(['stringCached']),
+          {
+            context,
+          }
+        )
+        return (
+          <div>
+            <h1>{data}</h1>
+          </div>
+        )
+      }
+
+      const rendered = render(
+        <QueryClientProvider client={queryClientOuter} context={context}>
+          <QueryClientProvider client={queryClientInner}>
+            <Page />
+          </QueryClientProvider>
+        </QueryClientProvider>
+      )
+
+      rendered.getByText('stringCached')
+      await sleep(10)
+      rendered.getByText('string')
+
+      queryClientInner.clear()
+      queryClientOuter.clear()
     })
   })
 

--- a/src/reactjs/tests/useMutation.test.tsx
+++ b/src/reactjs/tests/useMutation.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'
 import React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-import { useMutation, QueryCache, MutationCache } from '../..'
+import { QueryClient, useMutation, QueryCache, MutationCache } from '../..'
 import { UseMutationResult } from '../types'
 import {
   createQueryClient,
@@ -842,6 +842,71 @@ describe('useMutation', () => {
     expect(onSettled).toHaveBeenCalledTimes(1)
     expect(onSuccessMutate).toHaveBeenCalledTimes(0)
     expect(onSettledMutate).toHaveBeenCalledTimes(0)
+  })
+
+  describe('with custom context', () => {
+    it('should be able to reset `data`', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+
+      function Page() {
+        const { mutate, data = '', reset } = useMutation(
+          () => Promise.resolve('mutation'),
+          { context }
+        )
+
+        return (
+          <div>
+            <h1 data-testid="title">{data}</h1>
+            <button onClick={() => reset()}>reset</button>
+            <button onClick={() => mutate()}>mutate</button>
+          </div>
+        )
+      }
+
+      const { getByTestId, getByText } = renderWithClient(
+        queryClient,
+        <Page />,
+        { context }
+      )
+
+      expect(getByTestId('title').textContent).toBe('')
+
+      fireEvent.click(getByText('mutate'))
+
+      await waitFor(() => getByTestId('title'))
+
+      expect(getByTestId('title').textContent).toBe('mutation')
+
+      fireEvent.click(getByText('reset'))
+
+      await waitFor(() => getByTestId('title'))
+
+      expect(getByTestId('title').textContent).toBe('')
+    })
+
+    it('should throw if the context is not passed to useMutation', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+
+      function Page() {
+        const { data = '' } = useMutation(() => Promise.resolve('mutation'))
+
+        return (
+          <div>
+            <h1 data-testid="title">{data}</h1>
+          </div>
+        )
+      }
+
+      const rendered = renderWithClient(
+        queryClient,
+        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+          <Page />
+        </ErrorBoundary>,
+        { context }
+      )
+
+      await waitFor(() => rendered.getByText('error boundary'))
+    })
   })
 
   it('should call mutate callbacks only for the last observer', async () => {

--- a/src/reactjs/tests/useQueries.test.tsx
+++ b/src/reactjs/tests/useQueries.test.tsx
@@ -1,5 +1,6 @@
 import { waitFor, fireEvent } from '@testing-library/react'
 import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import * as QueriesObserverModule from '../../core/queriesObserver'
 
@@ -13,6 +14,7 @@ import {
   sleep,
 } from './utils'
 import {
+  QueryClient,
   useQueries,
   UseQueryResult,
   QueryCache,
@@ -1055,5 +1057,86 @@ describe('useQueries', () => {
 
     await sleep(20)
     QueriesObserverSpy.mockRestore()
+  })
+
+  describe('with custom context', () => {
+    it('should return the correct states', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const results: UseQueryResult[][] = []
+
+      function Page() {
+        const result = useQueries({
+          context,
+          queries: [
+            {
+              queryKey: key1,
+              queryFn: async () => {
+                await sleep(5)
+                return 1
+              },
+            },
+            {
+              queryKey: key2,
+              queryFn: async () => {
+                await sleep(10)
+                return 2
+              },
+            },
+          ],
+        })
+        results.push(result)
+        return null
+      }
+
+      renderWithClient(queryClient, <Page />, { context })
+
+      await sleep(30)
+
+      expect(results.length).toBe(3)
+      expect(results[0]).toMatchObject([
+        { data: undefined },
+        { data: undefined },
+      ])
+      expect(results[1]).toMatchObject([{ data: 1 }, { data: undefined }])
+      expect(results[2]).toMatchObject([{ data: 1 }, { data: 2 }])
+    })
+
+    it('should throw if the context is necessary and is not passed to useQueries', async () => {
+      const context = React.createContext<QueryClient | undefined>(undefined)
+
+      const key1 = queryKey()
+      const key2 = queryKey()
+      const results: UseQueryResult[][] = []
+
+      function Page() {
+        const result = useQueries({
+          queries: [
+            {
+              queryKey: key1,
+              queryFn: async () => 1,
+            },
+            {
+              queryKey: key2,
+              queryFn: async () => 2,
+            },
+          ],
+        })
+        results.push(result)
+        return null
+      }
+
+      const rendered = renderWithClient(
+        queryClient,
+        <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+          <Page />
+        </ErrorBoundary>,
+        { context }
+      )
+
+      await waitFor(() => rendered.getByText('error boundary'))
+    })
   })
 })

--- a/src/reactjs/tests/utils.tsx
+++ b/src/reactjs/tests/utils.tsx
@@ -6,6 +6,7 @@ import {
   QueryClient,
   QueryClientConfig,
   QueryClientProvider,
+  ContextOptions,
 } from '../..'
 import * as utils from '../../core/utils'
 
@@ -14,15 +15,23 @@ export function createQueryClient(config?: QueryClientConfig): QueryClient {
   return new QueryClient({ logger: mockLogger, ...config })
 }
 
-export function renderWithClient(client: QueryClient, ui: React.ReactElement) {
+export function renderWithClient(
+  client: QueryClient,
+  ui: React.ReactElement,
+  options: ContextOptions = {}
+) {
   const { rerender, ...result } = render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    <QueryClientProvider client={client} context={options.context}>
+      {ui}
+    </QueryClientProvider>
   )
   return {
     ...result,
     rerender: (rerenderUi: React.ReactElement) =>
       rerender(
-        <QueryClientProvider client={client}>{rerenderUi}</QueryClientProvider>
+        <QueryClientProvider client={client} context={options.context}>
+          {rerenderUi}
+        </QueryClientProvider>
       ),
   }
 }

--- a/src/reactjs/types.ts
+++ b/src/reactjs/types.ts
@@ -8,6 +8,14 @@ import {
   MutationObserverOptions,
   MutateFunction,
 } from '../core/types'
+import type { QueryClient } from '../core/queryClient'
+
+export interface ContextOptions {
+  /**
+   * Use this to pass your React Query context. Otherwise, the default will be used.
+   */
+  context?: React.Context<QueryClient | undefined>
+}
 
 export interface UseBaseQueryOptions<
   TQueryFnData = unknown,
@@ -15,13 +23,8 @@ export interface UseBaseQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  > {}
+> extends ContextOptions,
+    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {}
 
 export interface UseQueryOptions<
   TQueryFnData = unknown,
@@ -42,13 +45,14 @@ export interface UseInfiniteQueryOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends InfiniteQueryObserverOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryData,
-    TQueryKey
-  > {}
+> extends ContextOptions,
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    > {}
 
 export type UseBaseQueryResult<
   TData = unknown,
@@ -70,10 +74,11 @@ export interface UseMutationOptions<
   TError = unknown,
   TVariables = void,
   TContext = unknown
-> extends Omit<
-    MutationObserverOptions<TData, TError, TVariables, TContext>,
-    '_defaulted' | 'variables'
-  > {}
+> extends ContextOptions,
+    Omit<
+      MutationObserverOptions<TData, TError, TVariables, TContext>,
+      '_defaulted' | 'variables'
+    > {}
 
 export type UseMutateFunction<
   TData = unknown,

--- a/src/reactjs/types.ts
+++ b/src/reactjs/types.ts
@@ -12,7 +12,7 @@ import type { QueryClient } from '../core/queryClient'
 
 export interface ContextOptions {
   /**
-   * Use this to pass your React Query context. Otherwise, the default will be used.
+   * Use this to pass your React Query context. Otherwise, `defaultContext` will be used.
    */
   context?: React.Context<QueryClient | undefined>
 }

--- a/src/reactjs/useBaseQuery.ts
+++ b/src/reactjs/useBaseQuery.ts
@@ -27,7 +27,7 @@ export function useBaseQuery<
   const mountedRef = React.useRef(false)
   const [, forceUpdate] = React.useState(0)
 
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient({ context: options.context })
   const errorResetBoundary = useQueryErrorResetBoundary()
   const defaultedOptions = queryClient.defaultQueryOptions(options)
 

--- a/src/reactjs/useIsFetching.ts
+++ b/src/reactjs/useIsFetching.ts
@@ -2,23 +2,29 @@ import React from 'react'
 
 import { notifyManager } from '../core/notifyManager'
 import { QueryKey } from '../core/types'
+import { ContextOptions } from '../reactjs/types'
 import { parseFilterArgs, QueryFilters } from '../core/utils'
 import { useQueryClient } from './QueryClientProvider'
 
-export function useIsFetching(filters?: QueryFilters): number
+interface Options extends ContextOptions {}
+
+export function useIsFetching(filters?: QueryFilters, options?: Options): number
 export function useIsFetching(
   queryKey?: QueryKey,
-  filters?: QueryFilters
+  filters?: QueryFilters,
+  options?: Options
 ): number
 export function useIsFetching(
   arg1?: QueryKey | QueryFilters,
-  arg2?: QueryFilters
+  arg2?: QueryFilters | Options,
+  arg3?: Options
 ): number {
   const mountedRef = React.useRef(false)
 
-  const queryClient = useQueryClient()
+  const [filters, options = {}] = parseFilterArgs(arg1, arg2, arg3)
 
-  const [filters] = parseFilterArgs(arg1, arg2)
+  const queryClient = useQueryClient({ context: options.context })
+
   const [isFetching, setIsFetching] = React.useState(
     queryClient.isFetching(filters)
   )

--- a/src/reactjs/useIsMutating.ts
+++ b/src/reactjs/useIsMutating.ts
@@ -2,22 +2,30 @@ import React from 'react'
 
 import { notifyManager } from '../core/notifyManager'
 import { MutationKey } from '../core/types'
+import { ContextOptions } from '../reactjs/types'
 import { MutationFilters, parseMutationFilterArgs } from '../core/utils'
 import { useQueryClient } from './QueryClientProvider'
 
-export function useIsMutating(filters?: MutationFilters): number
+interface Options extends ContextOptions {}
+
+export function useIsMutating(
+  filters?: MutationFilters,
+  options?: Options
+): number
 export function useIsMutating(
   mutationKey?: MutationKey,
-  filters?: Omit<MutationFilters, 'mutationKey'>
+  filters?: Omit<MutationFilters, 'mutationKey'>,
+  options?: Options
 ): number
 export function useIsMutating(
   arg1?: MutationKey | MutationFilters,
-  arg2?: Omit<MutationFilters, 'mutationKey'>
+  arg2?: Omit<MutationFilters, 'mutationKey'> | Options,
+  arg3?: Options
 ): number {
   const mountedRef = React.useRef(false)
-  const filters = parseMutationFilterArgs(arg1, arg2)
+  const [filters, options = {}] = parseMutationFilterArgs(arg1, arg2, arg3)
 
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient({ context: options.context })
 
   const [isMutating, setIsMutating] = React.useState(
     queryClient.isMutating(filters)

--- a/src/reactjs/useMutation.ts
+++ b/src/reactjs/useMutation.ts
@@ -78,7 +78,7 @@ export function useMutation<
   const [, forceUpdate] = React.useState(0)
 
   const options = parseMutationArgs(arg1, arg2, arg3)
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient({ context: options.context })
 
   const obsRef = React.useRef<
     MutationObserver<TData, TError, TVariables, TContext>


### PR DESCRIPTION
This adds support for passing in a context as other robust libraries (such as Redux) support: https://react-redux.js.org/api/provider#props.

This is important as right now React Query supports creating multiple `queryClient` instances but does not currently support the ability to specify which `queryClient` instance should be used with `useQueryClient`. In the case of nested `QueryClientProvider` instances in an application, the ability to specify which context (and thus which `QueryClientProvider` and `queryClient`)  should be used is critical. This adds such capability.

These changes should be 100% backwards compatible.