### PR TITLE
fix(core): change `shouldFetchOptionally` condition

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -763,7 +763,7 @@ function shouldFetchOptionally(
   return (
     options.enabled !== false &&
     (query !== prevQuery || prevOptions.enabled === false) &&
-    query.state.status !== 'error' &&
+    prevQuery.state.status !== 'error' &&
     isStale(query, options)
   )
 }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -763,6 +763,7 @@ function shouldFetchOptionally(
   return (
     options.enabled !== false &&
     (query !== prevQuery || prevOptions.enabled === false) &&
+    query.state.status !== 'error' &&
     isStale(query, options)
   )
 }

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -763,7 +763,7 @@ function shouldFetchOptionally(
   return (
     options.enabled !== false &&
     (query !== prevQuery || prevOptions.enabled === false) &&
-    prevQuery.state.status !== 'error' &&
+    (prevQuery.state.status !== 'error' || prevOptions.enabled === false) &&
     isStale(query, options)
   )
 }

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -3883,4 +3883,65 @@ describe('useQuery', () => {
     expect(renders).toBe(2)
     expect(hashes).toBe(2)
   })
+
+  it('should refetch when changed enabled to true in error state', async () => {
+    const consoleMock = mockConsoleError()
+
+    const queryFn = jest.fn()
+    queryFn.mockImplementation(async () => {
+      await sleep(10)
+      return Promise.reject(new Error('Suspense Error Bingo'))
+    })
+
+    function Page({ enabled }: { enabled: boolean }) {
+      const { error, isLoading } = useQuery(['key'], queryFn, {
+        enabled,
+        retry: false,
+        retryOnMount: false,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+      })
+
+      if (isLoading) {
+        return <div>status: loading</div>
+      }
+      if (error instanceof Error) {
+        return <div>error</div>
+      }
+      return <div>rendered</div>
+    }
+
+    function App() {
+      const [enabled, toggle] = React.useReducer(x => !x, true)
+
+      return (
+        <div>
+          <Page enabled={enabled} />
+          <button aria-label="retry" onClick={toggle}>
+            retry {enabled}
+          </button>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <App />)
+
+    // initial state check
+    rendered.getByText('status: loading')
+
+    // // render error state component
+    await waitFor(() => rendered.getByText('error'))
+    expect(queryFn).toBeCalledTimes(1)
+
+    // change to enabled to false
+    fireEvent.click(rendered.getByLabelText('retry'))
+    await waitFor(() => rendered.getByText('error'))
+    expect(queryFn).toBeCalledTimes(1)
+
+    // // change to enabled to true
+    fireEvent.click(rendered.getByLabelText('retry'))
+    expect(queryFn).toBeCalledTimes(2)
+
+    consoleMock.mockRestore()
+  })
 })


### PR DESCRIPTION
Related issue: https://github.com/tannerlinsley/react-query/issues/2187

### Description

Change `shouldFetchOptionally` condition to not change the `status` of result to `loading` when `state.status` is `error`.

1. `result.isLoading` is `true` in [this line](https://github.com/tannerlinsley/react-query/blob/master/src/react/useBaseQuery.ts#L110) when `result.error != null`
2. So the error did not propagate to the error boundary. (next condition)
3. Check the `createResult` function and `shouldFetchOptionally` function

Fixes tannerlinsley/react-query#2187

> Special thanks to @flybayer 