### PR TITLE
fix(core): change `prevQuery` to `query` in `shouldFetchOptionally` function

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -763,7 +763,7 @@ function shouldFetchOptionally(
   return (
     options.enabled !== false &&
     (query !== prevQuery || prevOptions.enabled === false) &&
-    (prevQuery.state.status !== 'error' || prevOptions.enabled === false) &&
+    (query.state.status !== 'error' || prevOptions.enabled === false) &&
     isStale(query, options)
   )
 }


### PR DESCRIPTION
> related pull request: #2556 

### Description

Change `prevQuery` to `query` in `shouldFetchOptionally` because of checking query key changed
situation.

- This PR(#2556) fixes a bug which an error was not caught when the query was reset.
- When query key changed, infinity re-request is reproduced.
  - prevQuery.state.status === 'success'
  - query.state.status === 'error'

#### Checking

- [x] Is refetch when query key changed without suspense? -> **YES**
- [x] Catch error in `ErrorBoundary` when query key changed and thrown error with error boundary? -> **YES**