### PR TITLE
docs(ssr): Change useState to useMemo

### DIFF
--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -49,7 +49,7 @@ React Query supports prefetching multiple queries on the server in Next.js and t
 
 To support caching queries on the server and set up hydration:
 
-- Create a new `QueryClient` instance **inside of your app, and on an instance ref (or in React state). This ensures that data is not shared between different users and requests, while still only creating the QueryClient once per component lifecycle.**
+- Create a new `QueryClient` instance **inside of your app, and on an instance ref (or using memoization). This ensures that data is not shared between different users and requests, while still only creating the QueryClient once per component lifecycle.**
 - Wrap your app component with `<QueryClientProvider>` and pass it the client instance
 - Wrap your app component with `<Hydrate>` and pass it the `dehydratedState` prop from `pageProps`
 
@@ -59,7 +59,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { Hydrate } from 'react-query/hydration'
 
 export default function MyApp({ Component, pageProps }) {
-  const [queryClient] = React.useState(() => new QueryClient())
+  const queryClient = React.useMemo(() => new QueryClient(), [])
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Wouldn't `useMemo` be the more appropriate hook to use in this situation? While `useState` would accomplish the same thing, it seems like not the right tool for the job.