### PR TITLE
docs: Add link to 3rd party React Native devtools

### DIFF
--- a/docs/src/pages/react-native.md
+++ b/docs/src/pages/react-native.md
@@ -3,4 +3,8 @@ id: react-native
 title: React Native
 ---
 
-React Query is designed to work out of the box with React Native, with an exception to the devtools, which are only supported with React DOM at this time. If you would like to help us make the devtools platform agnostic, please let us know!
+React Query is designed to work out of the box with React Native, with the exception of the devtools, which are only supported with React DOM at this time. 
+
+There is a 3rd party [Flipper](https://fbflipper.com/docs/getting-started/react-native/) plugin which you can try: https://github.com/bgaleotti/react-query-native-devtools
+
+If you would like to help us make the built-in devtools platform agnostic, please let us know!


### PR DESCRIPTION
I've been using this Flipper plugin and it does the job well! Not super polished, but to have React Query devtools on React Native is a massive step up.

(I'm not affiliated, just found it the other day).

Also grammar improvements.