### PR TITLE
Do not render DevTools during SSR

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { useQueryClient } from 'react-query'
 import { matchSorter } from 'match-sorter'
 import useLocalStorage from './useLocalStorage'
-import { useSafeState } from './utils'
+import { useIsMounted, useSafeState } from './utils'
 
 import {
   Panel,
@@ -95,6 +95,7 @@ export function ReactQueryDevtools({
   )
   const [isResolvedOpen, setIsResolvedOpen] = useSafeState(false)
   const [isResizing, setIsResizing] = useSafeState(false)
+  const isMounted = useIsMounted()
 
   const handleDragStart = (panelElement, startEvent) => {
     if (startEvent.button !== 0) return // Only allow left click for drag
@@ -195,6 +196,9 @@ export function ReactQueryDevtools({
     onClick: onToggleClick,
     ...otherToggleButtonProps
   } = toggleButtonProps
+
+  // Do not render on the server
+  if (!isMounted()) return null
 
   return (
     <Container ref={rootRef} className="ReactQueryDevtools">
@@ -428,12 +432,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
 
     return (
       <ThemeProvider theme={theme}>
-        <Panel
-          ref={ref}
-          className="ReactQueryDevtoolsPanel"
-          {...panelProps}
-          suppressHydrationWarning
-        >
+        <Panel ref={ref} className="ReactQueryDevtoolsPanel" {...panelProps}>
           <style
             dangerouslySetInnerHTML={{
               __html: `
@@ -505,26 +504,22 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
               >
                 <QueryKeys style={{ marginBottom: '.5rem' }}>
                   <QueryKey
-                    suppressHydrationWarning
                     style={{
                       background: theme.success,
                       opacity: hasFresh ? 1 : 0.3,
                     }}
                   >
-                    fresh <Code suppressHydrationWarning>({hasFresh})</Code>
+                    fresh <Code>({hasFresh})</Code>
                   </QueryKey>{' '}
                   <QueryKey
-                    suppressHydrationWarning
                     style={{
                       background: theme.active,
                       opacity: hasFetching ? 1 : 0.3,
                     }}
                   >
-                    fetching{' '}
-                    <Code suppressHydrationWarning>({hasFetching})</Code>
+                    fetching <Code>({hasFetching})</Code>
                   </QueryKey>{' '}
                   <QueryKey
-                    suppressHydrationWarning
                     style={{
                       background: theme.warning,
                       color: 'black',
@@ -532,17 +527,15 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                       opacity: hasStale ? 1 : 0.3,
                     }}
                   >
-                    stale <Code suppressHydrationWarning>({hasStale})</Code>
+                    stale <Code>({hasStale})</Code>
                   </QueryKey>{' '}
                   <QueryKey
-                    suppressHydrationWarning
                     style={{
                       background: theme.gray,
                       opacity: hasInactive ? 1 : 0.3,
                     }}
                   >
-                    inactive{' '}
-                    <Code suppressHydrationWarning>({hasInactive})</Code>
+                    inactive <Code>({hasInactive})</Code>
                   </QueryKey>
                 </QueryKeys>
                 <div
@@ -597,7 +590,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
               </div>
             </div>
             <div
-              suppressHydrationWarning
               style={{
                 overflowY: 'auto',
                 flex: '1',
@@ -605,7 +597,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
             >
               {queries.map((query, i) => (
                 <div
-                  suppressHydrationWarning
                   key={query.queryHash || i}
                   role="button"
                   aria-label={`Open query details for ${query.queryHash}`}
@@ -625,7 +616,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                   }}
                 >
                   <div
-                    suppressHydrationWarning
                     style={{
                       flex: '0 0 auto',
                       width: '2rem',
@@ -649,7 +639,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                   </div>
                   {query.isActive() ? null : (
                     <div
-                      suppressHydrationWarning
                       style={{
                         flex: '0 0 auto',
                         height: '2rem',
@@ -664,7 +653,6 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                     </div>
                   )}
                   <Code
-                    suppressHydrationWarning
                     style={{
                       padding: '.5rem',
                     }}

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -58,7 +58,7 @@ export function styled(type, newStyles, queries = {}) {
   })
 }
 
-function useIsMounted() {
+export function useIsMounted() {
   const mountedRef = React.useRef(false)
   const isMounted = React.useCallback(() => mountedRef.current, [])
 


### PR DESCRIPTION
This PR makes the DevTools client-side-only to avoid hydration issues (see https://github.com/tannerlinsley/react-query/issues/1774).

It renders `ReactQueryDevtools` as `null` during SSR, and then renders normally after mount.

I'm experiencing a failed test on my machine, even on the `master` branch without any change of mine:

```
Expected: "[\"query-2\"]"
    Received: "[\"query-1\"]"

      324 |     fireEvent.change(sortSelect, { target: { value: 'Last Updated' } })
      325 |     queries = await screen.findAllByText(/\["query-[1-3]"\]/)
    > 326 |     expect(queries[0]?.textContent).toEqual(query2Hash)
          |                                     ^
      327 |     expect(queries[1]?.textContent).toEqual(query3Hash)
      328 |     expect(queries[2]?.textContent).toEqual(query1Hash)
      329 | 

      at src/devtools/tests/devtools.test.tsx:326:37
```

With my changes, the failed test is different:

```
Expected: "[\"query-2\"]"
    Received: "[\"query-3\"]"

      324 |     fireEvent.change(sortSelect, { target: { value: 'Last Updated' } })
      325 |     queries = await screen.findAllByText(/\["query-[1-3]"\]/)
    > 326 |     expect(queries[0]?.textContent).toEqual(query2Hash)
          |                                     ^
      327 |     expect(queries[1]?.textContent).toEqual(query3Hash)
      328 |     expect(queries[2]?.textContent).toEqual(query1Hash)
      329 | 

      at src/devtools/tests/devtools.test.tsx:326:37
```

Maybe @prateek3255 would know what's going on?