### PR TITLE
Allow handling some errors locally while using error boundaries

### DIFF
--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -23,7 +23,6 @@ await queryClient.prefetchQuery('posts', fetchPosts)
 
 Its available methods are:
 
-- [`QueryClient`](#queryclient)
 - [`queryClient.fetchQuery`](#queryclientfetchquery)
 - [`queryClient.fetchInfiniteQuery`](#queryclientfetchinfinitequery)
 - [`queryClient.prefetchQuery`](#queryclientprefetchquery)
@@ -271,15 +270,11 @@ The `invalidateQueries` method can be used to invalidate and refetch single or m
 - If you **want inactive queries to refetch** as well, use the `refetchInactive: true` option
 
 ```js
-await queryClient.invalidateQueries(
-  'posts',
-  {
-    exact,
-    refetchActive: true,
-    refetchInactive: false,
-  },
-  { throwOnError }
-)
+await queryClient.invalidateQueries('posts', {
+  exact,
+  refetchActive: true,
+  refetchInactive: false
+}, { throwOnError })
 ```
 
 **Options**
@@ -440,7 +435,6 @@ React Query also exports a handy [`useIsMutating`](./useIsMutating) hook that wi
 **Returns**
 
 This method returns the number of fetching mutations.
-
 ## `queryClient.getDefaultOptions`
 
 The `getDefaultOptions` method returns the default options which have been set when creating the client or with `setDefaultOptions`.

--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -23,6 +23,7 @@ await queryClient.prefetchQuery('posts', fetchPosts)
 
 Its available methods are:
 
+- [`QueryClient`](#queryclient)
 - [`queryClient.fetchQuery`](#queryclientfetchquery)
 - [`queryClient.fetchInfiniteQuery`](#queryclientfetchinfinitequery)
 - [`queryClient.prefetchQuery`](#queryclientprefetchquery)
@@ -91,7 +92,7 @@ try {
 
 **Options**
 
-The options for `fetchQuery` are exactly the same as those of [`useQuery`](./useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, notifyOnChangeProps, notifyOnChangePropsExclusions, onSuccess, onError, onSettled, useErrorBoundary, select, suspense, keepPreviousData, placeholderData`; which are stictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/tannerlinsley/react-query/blob/361935a12cec6f36d0bd6ba12e84136c405047c5/src/core/types.ts#L83) for more clarity.
+The options for `fetchQuery` are exactly the same as those of [`useQuery`](./useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, notifyOnChangeProps, notifyOnChangePropsExclusions, onSuccess, onError, onSettled, useErrorBoundary, shouldThrowError, select, suspense, keepPreviousData, placeholderData`; which are stictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/tannerlinsley/react-query/blob/361935a12cec6f36d0bd6ba12e84136c405047c5/src/core/types.ts#L83) for more clarity.
 
 **Returns**
 
@@ -270,11 +271,15 @@ The `invalidateQueries` method can be used to invalidate and refetch single or m
 - If you **want inactive queries to refetch** as well, use the `refetchInactive: true` option
 
 ```js
-await queryClient.invalidateQueries('posts', {
-  exact,
-  refetchActive: true,
-  refetchInactive: false
-}, { throwOnError })
+await queryClient.invalidateQueries(
+  'posts',
+  {
+    exact,
+    refetchActive: true,
+    refetchInactive: false,
+  },
+  { throwOnError }
+)
 ```
 
 **Options**
@@ -435,6 +440,7 @@ React Query also exports a handy [`useIsMutating`](./useIsMutating) hook that wi
 **Returns**
 
 This method returns the number of fetching mutations.
+
 ## `queryClient.getDefaultOptions`
 
 The `getDefaultOptions` method returns the default options which have been set when creating the client or with `setDefaultOptions`.

--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -92,7 +92,7 @@ try {
 
 **Options**
 
-The options for `fetchQuery` are exactly the same as those of [`useQuery`](./useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, notifyOnChangeProps, notifyOnChangePropsExclusions, onSuccess, onError, onSettled, useErrorBoundary, shouldThrowError, select, suspense, keepPreviousData, placeholderData`; which are stictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/tannerlinsley/react-query/blob/361935a12cec6f36d0bd6ba12e84136c405047c5/src/core/types.ts#L83) for more clarity.
+The options for `fetchQuery` are exactly the same as those of [`useQuery`](./useQuery), except the following: `enabled, refetchInterval, refetchIntervalInBackground, refetchOnWindowFocus, refetchOnReconnect, notifyOnChangeProps, notifyOnChangePropsExclusions, onSuccess, onError, onSettled, useErrorBoundary, select, suspense, keepPreviousData, placeholderData`; which are stictly for useQuery and useInfiniteQuery. You can check the [source code](https://github.com/tannerlinsley/react-query/blob/361935a12cec6f36d0bd6ba12e84136c405047c5/src/core/types.ts#L83) for more clarity.
 
 **Returns**
 

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -23,6 +23,7 @@ const {
   onSettled,
   onSuccess,
   useErrorBoundary,
+  shouldThrowError,
 })
 
 mutate(variables, {
@@ -69,6 +70,9 @@ mutate(variables, {
 - `useErrorBoundary`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
+- `shouldThrowError: () => boolean`
+  - Default to throwing all errors
+  - Use this if you want to use `useErrorBoundary` or `suspense`, but want to handle some errors locally without them being thrown.
 
 **Returns**
 

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -66,7 +66,7 @@ mutate(variables, {
   - This function receives a `retryAttempt` integer and the actual Error and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.
   - A function like `attempt => attempt * 1000` applies linear backoff.
-- `useErrorBoundary: boolean | (err: TError) => boolean`
+- `useErrorBoundary: boolean | (error: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
   - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -69,7 +69,7 @@ mutate(variables, {
 - `useErrorBoundary: undefined | boolean | (error: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `undefined`
   - Set this to `true` if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
-  - Set this to `false` to disable `suspense`'s default behaviour of throwing errors to the error boundary.
+  - Set this to `false` to disable the behaviour of throwing errors to the error boundary.
   - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 
 **Returns**

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -66,9 +66,10 @@ mutate(variables, {
   - This function receives a `retryAttempt` integer and the actual Error and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.
   - A function like `attempt => attempt * 1000` applies linear backoff.
-- `useErrorBoundary: boolean | (error: TError) => boolean`
-  - Defaults to the global query config's `useErrorBoundary` value, which is `false`
-  - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
+- `useErrorBoundary: undefined | boolean | (error: TError) => boolean`
+  - Defaults to the global query config's `useErrorBoundary` value, which is `undefined`
+  - Set this to `true` if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
+  - Set this to `false` to disable `suspense`'s default behaviour of throwing errors to the error boundary.
   - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 
 **Returns**

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -23,7 +23,6 @@ const {
   onSettled,
   onSuccess,
   useErrorBoundary,
-  shouldThrowError,
 })
 
 mutate(variables, {
@@ -67,12 +66,10 @@ mutate(variables, {
   - This function receives a `retryAttempt` integer and the actual Error and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.
   - A function like `attempt => attempt * 1000` applies linear backoff.
-- `useErrorBoundary`
+- `useErrorBoundary: boolean | (err: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
-- `shouldThrowError: () => boolean`
-  - Default to throwing all errors
-  - Use this if you want to use `useErrorBoundary` or `suspense`, but want to handle some errors locally without them being thrown.
+  - If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`)
 
 **Returns**
 

--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -69,7 +69,7 @@ mutate(variables, {
 - `useErrorBoundary: boolean | (err: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want mutation errors to be thrown in the render phase and propagate to the nearest error boundary
-  - If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`)
+  - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -173,7 +173,7 @@ const result = useQuery({
 - `useErrorBoundary: boolean | (err: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want errors to be thrown in the render phase and propagate to the nearest error boundary
-  - If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`)
+  - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -170,9 +170,10 @@ const result = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.
-- `useErrorBoundary: boolean | (error: TError) => boolean`
-  - Defaults to the global query config's `useErrorBoundary` value, which is `false`
-  - Set this to true if you want errors to be thrown in the render phase and propagate to the nearest error boundary
+- `useErrorBoundary: undefined | boolean | (error: TError) => boolean`
+  - Defaults to the global query config's `useErrorBoundary` value, which is `undefined`
+  - Set this to `true` if you want errors to be thrown in the render phase and propagate to the nearest error boundary
+  - Set this to `false` to disable `suspense`'s default behaviour of throwing errors to the error boundary.
   - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)
 
 **Returns**

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -51,6 +51,7 @@ const {
   structuralSharing,
   suspense,
   useErrorBoundary,
+  shouldThrowError,
 })
 
 // or using the object syntax
@@ -173,6 +174,9 @@ const result = useQuery({
 - `useErrorBoundary: boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is false
   - Set this to true if you want errors to be thrown in the render phase and propagated to the nearest error boundary
+- `shouldThrowError: () => boolean`
+  - Default to throwing all errors
+  - Use this if you want to use `useErrorBoundary` or `suspense`, but want to handle some errors locally without them being thrown.
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -51,7 +51,6 @@ const {
   structuralSharing,
   suspense,
   useErrorBoundary,
-  shouldThrowError,
 })
 
 // or using the object syntax
@@ -171,12 +170,10 @@ const result = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.
-- `useErrorBoundary: boolean`
-  - Defaults to the global query config's `useErrorBoundary` value, which is false
-  - Set this to true if you want errors to be thrown in the render phase and propagated to the nearest error boundary
-- `shouldThrowError: () => boolean`
-  - Default to throwing all errors
-  - Use this if you want to use `useErrorBoundary` or `suspense`, but want to handle some errors locally without them being thrown.
+- `useErrorBoundary: boolean | (err: TError) => boolean`
+  - Defaults to the global query config's `useErrorBoundary` value, which is `false`
+  - Set this to true if you want errors to be thrown in the render phase and propagate to the nearest error boundary
+  - If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`)
 
 **Returns**
 

--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -170,7 +170,7 @@ const result = useQuery({
   - Optional
   - Defaults to `true`
   - If set to `false`, structural sharing between query results will be disabled.
-- `useErrorBoundary: boolean | (err: TError) => boolean`
+- `useErrorBoundary: boolean | (error: TError) => boolean`
   - Defaults to the global query config's `useErrorBoundary` value, which is `false`
   - Set this to true if you want errors to be thrown in the render phase and propagate to the nearest error boundary
   - If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -163,13 +163,12 @@ export interface QueryObserverOptions<
   onSettled?: (data: TData | undefined, error: TError | null) => void
   /**
    * Whether errors should be thrown instead of setting the `error` property.
+   * If set to `true` or `suspense` is `true`, all errors will be thrown to the error boundary.
+   * If set to `false` and `suspense` is `false`, errors are returned as state.
+   * If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`).
    * Defaults to `false`.
    */
-  useErrorBoundary?: boolean
-  /**
-   * If an error is to be thrown by `useErrorBoundary`/`suspense` returning false from this callback will place that error in `error` instead.
-   */
-  shouldThrowError?: (err: TError) => boolean
+  useErrorBoundary?: boolean | ((err: TError) => boolean)
   /**
    * This option can be used to transform or select a part of the data returned by the query function.
    */
@@ -531,8 +530,7 @@ export interface MutationObserverOptions<
   TVariables = void,
   TContext = unknown
 > extends MutationOptions<TData, TError, TVariables, TContext> {
-  useErrorBoundary?: boolean
-  shouldThrowError?: (err: TError) => boolean
+  useErrorBoundary?: boolean | ((err: TError) => boolean)
 }
 
 export interface MutateOptions<

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -168,7 +168,7 @@ export interface QueryObserverOptions<
    * If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`).
    * Defaults to `false`.
    */
-  useErrorBoundary?: boolean | ((err: TError) => boolean)
+  useErrorBoundary?: boolean | ((error: TError) => boolean)
   /**
    * This option can be used to transform or select a part of the data returned by the query function.
    */
@@ -530,7 +530,7 @@ export interface MutationObserverOptions<
   TVariables = void,
   TContext = unknown
 > extends MutationOptions<TData, TError, TVariables, TContext> {
-  useErrorBoundary?: boolean | ((err: TError) => boolean)
+  useErrorBoundary?: boolean | ((error: TError) => boolean)
 }
 
 export interface MutateOptions<

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -167,6 +167,10 @@ export interface QueryObserverOptions<
    */
   useErrorBoundary?: boolean
   /**
+   * If an error is to be thrown by `useErrorBoundary`/`suspense` returning false from this callback will place that error in `error` instead.
+   */
+  shouldThrowError?: (err: TError) => boolean
+  /**
    * This option can be used to transform or select a part of the data returned by the query function.
    */
   select?: (data: TQueryData) => TData
@@ -528,6 +532,7 @@ export interface MutationObserverOptions<
   TContext = unknown
 > extends MutationOptions<TData, TError, TVariables, TContext> {
   useErrorBoundary?: boolean
+  shouldThrowError?: (err: TError) => boolean
 }
 
 export interface MutateOptions<

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -165,7 +165,7 @@ export interface QueryObserverOptions<
    * Whether errors should be thrown instead of setting the `error` property.
    * If set to `true` or `suspense` is `true`, all errors will be thrown to the error boundary.
    * If set to `false` and `suspense` is `false`, errors are returned as state.
-   * If set to a function, it will be passed the error and should return a boolean indicating whether to throw the error (`true`) or return the error as state (`false`).
+   * If set to a function, it will be passed the error and should return a boolean indicating whether to show the error in an error boundary (`true`) or return the error as state (`false`).
    * Defaults to `false`.
    */
   useErrorBoundary?: boolean | ((err: TError) => boolean)

--- a/src/react/tests/suspense.test.tsx
+++ b/src/react/tests/suspense.test.tsx
@@ -550,6 +550,185 @@ describe("useQuery's in Suspense mode", () => {
     consoleMock.mockRestore()
   })
 
+  it('should throw errors to the error boundary by default', async () => {
+    const key = queryKey()
+
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      useQuery(
+        key,
+        async () => {
+          await sleep(10)
+          throw new Error('Suspense Error a1x')
+        },
+        {
+          retry: false,
+          suspense: true,
+        }
+      )
+      return <div>rendered</div>
+    }
+
+    function App() {
+      return (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div>
+              <div>error boundary</div>
+            </div>
+          )}
+        >
+          <React.Suspense fallback="Loading...">
+            <Page />
+          </React.Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <App />)
+
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('error boundary'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should not throw errors to the error boundary when useErrorBoundary: false', async () => {
+    const key = queryKey()
+
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      useQuery(
+        key,
+        async () => {
+          await sleep(10)
+          throw new Error('Suspense Error a2x')
+        },
+        {
+          retry: false,
+          suspense: true,
+          useErrorBoundary: false,
+        }
+      )
+      return <div>rendered</div>
+    }
+
+    function App() {
+      return (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div>
+              <div>error boundary</div>
+            </div>
+          )}
+        >
+          <React.Suspense fallback="Loading...">
+            <Page />
+          </React.Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <App />)
+
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('rendered'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should not throw errors to the error boundary when a useErrorBoundary function returns true', async () => {
+    const key = queryKey()
+
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      useQuery(
+        key,
+        async () => {
+          await sleep(10)
+          return Promise.reject('Remote Error')
+        },
+        {
+          retry: false,
+          suspense: true,
+          useErrorBoundary: err => err !== 'Local Error',
+        }
+      )
+      return <div>rendered</div>
+    }
+
+    function App() {
+      return (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div>
+              <div>error boundary</div>
+            </div>
+          )}
+        >
+          <React.Suspense fallback="Loading...">
+            <Page />
+          </React.Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <App />)
+
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('error boundary'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should not throw errors to the error boundary when a useErrorBoundary function returns false', async () => {
+    const key = queryKey()
+
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      useQuery(
+        key,
+        async () => {
+          await sleep(10)
+          return Promise.reject('Local Error')
+        },
+        {
+          retry: false,
+          suspense: true,
+          useErrorBoundary: err => err !== 'Local Error',
+        }
+      )
+      return <div>rendered</div>
+    }
+
+    function App() {
+      return (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div>
+              <div>error boundary</div>
+            </div>
+          )}
+        >
+          <React.Suspense fallback="Loading...">
+            <Page />
+          </React.Suspense>
+        </ErrorBoundary>
+      )
+    }
+
+    const rendered = renderWithClient(queryClient, <App />)
+
+    await waitFor(() => rendered.getByText('Loading...'))
+    await waitFor(() => rendered.getByText('rendered'))
+
+    consoleMock.mockRestore()
+  })
+
   it('should not call the queryFn when not enabled', async () => {
     const key = queryKey()
 

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -19,6 +19,7 @@ import {
   QueryFunction,
   QueryFunctionContext,
 } from '../..'
+import { ErrorBoundary } from 'react-error-boundary'
 
 describe('useQuery', () => {
   const queryCache = new QueryCache()
@@ -2548,6 +2549,116 @@ describe('useQuery', () => {
 
     await waitFor(() => rendered.getByText('error'))
     await waitFor(() => rendered.getByText('Error test jaylen'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should throw error if queryFn throws and useErrorBoundary is in use', async () => {
+    const key = queryKey()
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      const { status, error } = useQuery<undefined, string>(
+        key,
+        () => Promise.reject('Error test jaylen'),
+        { retry: false, useErrorBoundary: true }
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+          <h2>{error}</h2>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>
+    )
+
+    await waitFor(() => rendered.getByText('error boundary'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should set status to error instead of throwing when error should not be thrown', async () => {
+    const key = queryKey()
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      const { status, error } = useQuery<undefined, string>(
+        key,
+        () => Promise.reject('Local Error'),
+        {
+          retry: false,
+          useErrorBoundary: true,
+          shouldThrowError: err => err !== 'Local Error',
+        }
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+          <h2>{error}</h2>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary fallbackRender={() => <div>error boundary</div>}>
+        <Page />
+      </ErrorBoundary>
+    )
+
+    await waitFor(() => rendered.getByText('error'))
+    await waitFor(() => rendered.getByText('Local Error'))
+
+    consoleMock.mockRestore()
+  })
+
+  it('should throw error instead of setting status when error should be thrown', async () => {
+    const key = queryKey()
+    const consoleMock = mockConsoleError()
+
+    function Page() {
+      const { status, error } = useQuery<undefined, string>(
+        key,
+        () => Promise.reject('Remote Error'),
+        {
+          retry: false,
+          useErrorBoundary: true,
+          shouldThrowError: err => err !== 'Local Error',
+        }
+      )
+
+      return (
+        <div>
+          <h1>{status}</h1>
+          <h2>{error}</h2>
+        </div>
+      )
+    }
+
+    const rendered = renderWithClient(
+      queryClient,
+      <ErrorBoundary
+        fallbackRender={({ error }) => (
+          <div>
+            <div>error boundary</div>
+            <div>{error}</div>
+          </div>
+        )}
+      >
+        <Page />
+      </ErrorBoundary>
+    )
+
+    await waitFor(() => rendered.getByText('error boundary'))
+    await waitFor(() => rendered.getByText('Remote Error'))
 
     consoleMock.mockRestore()
   })

--- a/src/react/tests/useQuery.test.tsx
+++ b/src/react/tests/useQuery.test.tsx
@@ -2594,8 +2594,7 @@ describe('useQuery', () => {
         () => Promise.reject('Local Error'),
         {
           retry: false,
-          useErrorBoundary: true,
-          shouldThrowError: err => err !== 'Local Error',
+          useErrorBoundary: err => err !== 'Local Error',
         }
       )
 
@@ -2630,8 +2629,7 @@ describe('useQuery', () => {
         () => Promise.reject('Remote Error'),
         {
           retry: false,
-          useErrorBoundary: true,
-          shouldThrowError: err => err !== 'Local Error',
+          useErrorBoundary: err => err !== 'Local Error',
         }
       )
 

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -96,8 +96,7 @@ export interface UseMutationOptions<
   ) => Promise<unknown> | void
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
-  useErrorBoundary?: boolean
-  shouldThrowError?: (err: TError) => boolean
+  useErrorBoundary?: boolean | ((err: TError) => boolean)
 }
 
 export type UseMutateFunction<

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -97,6 +97,7 @@ export interface UseMutationOptions<
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
   useErrorBoundary?: boolean
+  shouldThrowError?: (err: TError) => boolean
 }
 
 export type UseMutateFunction<

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -96,7 +96,7 @@ export interface UseMutationOptions<
   ) => Promise<unknown> | void
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
-  useErrorBoundary?: boolean | ((err: TError) => boolean)
+  useErrorBoundary?: boolean | ((error: TError) => boolean)
 }
 
 export type UseMutateFunction<

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -6,6 +6,7 @@ import { QueryObserver } from '../core/queryObserver'
 import { useQueryErrorResetBoundary } from './QueryErrorResetBoundary'
 import { useQueryClient } from './QueryClientProvider'
 import { UseBaseQueryOptions } from './types'
+import { shouldThrowError } from './utils'
 
 export function useBaseQuery<
   TQueryFnData,
@@ -123,12 +124,13 @@ export function useBaseQuery<
 
   // Handle error boundary
   if (
-    (defaultedOptions.suspense || defaultedOptions.useErrorBoundary) &&
     result.isError &&
     !result.isFetching &&
-    (defaultedOptions.shouldThrowError
-      ? defaultedOptions.shouldThrowError(result.error)
-      : true)
+    shouldThrowError(
+      defaultedOptions.suspense,
+      defaultedOptions.useErrorBoundary,
+      result.error
+    )
   ) {
     throw result.error
   }

--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -125,7 +125,10 @@ export function useBaseQuery<
   if (
     (defaultedOptions.suspense || defaultedOptions.useErrorBoundary) &&
     result.isError &&
-    !result.isFetching
+    !result.isFetching &&
+    (defaultedOptions.shouldThrowError
+      ? defaultedOptions.shouldThrowError(result.error)
+      : true)
   ) {
     throw result.error
   }

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -102,7 +102,13 @@ export function useMutation<
     obsRef.current!.mutate(variables, mutateOptions).catch(noop)
   }, [])
 
-  if (currentResult.error && obsRef.current.options.useErrorBoundary) {
+  if (
+    currentResult.error &&
+    obsRef.current.options.useErrorBoundary &&
+    (obsRef.current.options.shouldThrowError
+      ? obsRef.current.options.shouldThrowError(currentResult.error)
+      : true)
+  ) {
     throw currentResult.error
   }
 

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -10,6 +10,7 @@ import {
   UseMutationResult,
 } from './types'
 import { MutationFunction, MutationKey } from '../core/types'
+import { shouldThrowError } from './utils'
 
 // HOOK
 
@@ -104,10 +105,11 @@ export function useMutation<
 
   if (
     currentResult.error &&
-    obsRef.current.options.useErrorBoundary &&
-    (obsRef.current.options.shouldThrowError
-      ? obsRef.current.options.shouldThrowError(currentResult.error)
-      : true)
+    shouldThrowError(
+      undefined,
+      obsRef.current.options.useErrorBoundary,
+      currentResult.error
+    )
   ) {
     throw currentResult.error
   }

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -3,9 +3,14 @@ export function shouldThrowError<TError>(
   _useErrorBoundary: boolean | ((err: TError) => boolean) | undefined,
   error: TError
 ): boolean {
+  // Allow useErrorBoundary function to override throwing behavior on a per-error basis
   if (typeof _useErrorBoundary === 'function') {
     return _useErrorBoundary(error)
   }
 
-  return !!suspense || !!_useErrorBoundary
+  // Allow useErrorBoundary to override suspense's throwing behaviour
+  if (typeof _useErrorBoundary === 'boolean') return _useErrorBoundary
+
+  // If suspense is enabled default to throwing errors
+  return !!suspense
 }

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,6 +1,6 @@
 export function shouldThrowError<TError>(
   suspense: boolean | undefined,
-  _useErrorBoundary: boolean | ((err: TError) => boolean) | undefined,
+  _useErrorBoundary: boolean | ((error: TError) => boolean) | undefined,
   error: TError
 ): boolean {
   if (typeof _useErrorBoundary === 'function') {

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,6 +1,6 @@
 export function shouldThrowError<TError>(
   suspense: boolean | undefined,
-  _useErrorBoundary: boolean | ((error: TError) => boolean) | undefined,
+  _useErrorBoundary: boolean | ((err: TError) => boolean) | undefined,
   error: TError
 ): boolean {
   if (typeof _useErrorBoundary === 'function') {

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,0 +1,11 @@
+export function shouldThrowError<TError>(
+  suspense: boolean | undefined,
+  _useErrorBoundary: boolean | ((err: TError) => boolean) | undefined,
+  error: TError
+): boolean {
+  if (typeof _useErrorBoundary === 'function') {
+    return _useErrorBoundary(error)
+  }
+
+  return !!suspense || !!_useErrorBoundary
+}


### PR DESCRIPTION
This adds a `shouldThrowError` option that can be used when `useErrorBoundary`/`suspense` to decide whether an error should be thrown or handled locally on the `error` state.

It's nice to have errors thrown to error boundaries. However sometimes you have some errors you do want to handle within the component instead of having them thrown to external boundaries.

e.g. In a product list page you may want to handle an "invalid product filter" from the server with an in-list error instead of it being thrown out to an error boundary. But you still may want to use an error boundary so 500 errors from the server and network errors still get thrown out to a shared error boundary.