### PR TITLE
docs(useQuery): simplify disabling queries example

### DIFF
--- a/docs/src/pages/guides/disabling-queries.md
+++ b/docs/src/pages/guides/disabling-queries.md
@@ -29,27 +29,33 @@ function Todos() {
   } = useQuery('todos', fetchTodoList, {
     enabled: false,
   })
+  
+  let todos;
+  
+  if (isIdle) {
+    todos = 'Not ready...'
+  } else if (isLoading) {
+    todos = 'Loading...'
+  } else if (isError) {
+    todos = <span>Error: {error.message}</span>
+  } else {
+    todos = (
+      <>
+        <ul>
+          {data.map(todo => (
+            <li key={todo.id}>{todo.title}</li>
+          ))}
+        </ul>
+        <div>{isFetching ? 'Fetching...' : null}</div>
+      </>
+    )
+  }
 
   return (
     <>
       <button onClick={() => refetch()}>Fetch Todos</button>
 
-      {isIdle ? (
-        'Not ready...'
-      ) : isLoading ? (
-        <span>Loading...</span>
-      ) : isError ? (
-        <span>Error: {error.message}</span>
-      ) : (
-        <>
-          <ul>
-            {data.map(todo => (
-              <li key={todo.id}>{todo.title}</li>
-            ))}
-          </ul>
-          <div>{isFetching ? 'Fetching...' : null}</div>
-        </>
-      )}
+      {todos}
     </>
   )
 }


### PR DESCRIPTION
### Commit Message

You may copy this for squash and merge:
```
docs(useQuery): simplify disabling queries example

Change conditional rendering to `if` - `else` instead of nested ternary
```

### PR Notes

Hi, proposing a stylistic change which makes the example easier to understand (subjectively). Please feel free to close the PR if you'd prefer the existing convention :)