### PR TITLE
fix(types): fix generics for refetchPage function

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -184,13 +184,13 @@ export class QueryClient {
     })
   }
 
-  resetQueries(
-    filters?: ResetQueryFilters,
+  resetQueries<TPageData = unknown>(
+    filters?: ResetQueryFilters<TPageData>,
     options?: ResetOptions
   ): Promise<void>
-  resetQueries(
+  resetQueries<TPageData = unknown>(
     queryKey?: QueryKey,
-    filters?: ResetQueryFilters,
+    filters?: ResetQueryFilters<TPageData>,
     options?: ResetOptions
   ): Promise<void>
   resetQueries(
@@ -238,13 +238,13 @@ export class QueryClient {
     return Promise.all(promises).then(noop).catch(noop)
   }
 
-  invalidateQueries(
-    filters?: InvalidateQueryFilters,
+  invalidateQueries<TPageData = unknown>(
+    filters?: InvalidateQueryFilters<TPageData>,
     options?: InvalidateOptions
   ): Promise<void>
-  invalidateQueries(
+  invalidateQueries<TPageData = unknown>(
     queryKey?: QueryKey,
-    filters?: InvalidateQueryFilters,
+    filters?: InvalidateQueryFilters<TPageData>,
     options?: InvalidateOptions
   ): Promise<void>
   invalidateQueries(
@@ -270,13 +270,13 @@ export class QueryClient {
     })
   }
 
-  refetchQueries(
-    filters?: RefetchQueryFilters,
+  refetchQueries<TPageData = unknown>(
+    filters?: RefetchQueryFilters<TPageData>,
     options?: RefetchOptions
   ): Promise<void>
-  refetchQueries(
+  refetchQueries<TPageData = unknown>(
     queryKey?: QueryKey,
-    filters?: RefetchQueryFilters,
+    filters?: RefetchQueryFilters<TPageData>,
     options?: RefetchOptions
   ): Promise<void>
   refetchQueries(

--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -275,8 +275,8 @@ export class QueryObserver<
     this.client.getQueryCache().remove(this.currentQuery)
   }
 
-  refetch(
-    options?: RefetchOptions & RefetchQueryFilters<TData>
+  refetch<TPageData>(
+    options?: RefetchOptions & RefetchQueryFilters<TPageData>
   ): Promise<QueryObserverResult<TData, TError>> {
     return this.fetch({
       ...options,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -236,11 +236,11 @@ export interface ResultOptions {
   throwOnError?: boolean
 }
 
-export interface RefetchPageFilters<TQueryFnData = unknown> {
+export interface RefetchPageFilters<TPageData = unknown> {
   refetchPage?: (
-    lastPage: TQueryFnData,
+    lastPage: TPageData,
     index: number,
-    allPages: TQueryFnData[]
+    allPages: TPageData[]
   ) => boolean
 }
 
@@ -248,20 +248,20 @@ export interface RefetchOptions extends ResultOptions {
   cancelRefetch?: boolean
 }
 
-export interface InvalidateQueryFilters<TQueryFnData = unknown>
+export interface InvalidateQueryFilters<TPageData = unknown>
   extends QueryFilters,
-    RefetchPageFilters<TQueryFnData> {
+    RefetchPageFilters<TPageData> {
   refetchActive?: boolean
   refetchInactive?: boolean
 }
 
-export interface RefetchQueryFilters<TQueryFnData = unknown>
+export interface RefetchQueryFilters<TPageData = unknown>
   extends QueryFilters,
-    RefetchPageFilters<TQueryFnData> {}
+    RefetchPageFilters<TPageData> {}
 
-export interface ResetQueryFilters<TQueryFnData = unknown>
+export interface ResetQueryFilters<TPageData = unknown>
   extends QueryFilters,
-    RefetchPageFilters<TQueryFnData> {}
+    RefetchPageFilters<TPageData> {}
 
 export interface InvalidateOptions {
   throwOnError?: boolean
@@ -299,8 +299,8 @@ export interface QueryObserverBaseResult<TData = unknown, TError = unknown> {
   isRefetchError: boolean
   isStale: boolean
   isSuccess: boolean
-  refetch: (
-    options?: RefetchOptions & RefetchQueryFilters<TData>
+  refetch: <TPageData>(
+    options?: RefetchOptions & RefetchQueryFilters<TPageData>
   ) => Promise<QueryObserverResult<TData, TError>>
   remove: () => void
   status: QueryStatus


### PR DESCRIPTION
two issues:

1) The types inferred for the `refetch` function returned from useInfiniteQuery were wrong, as the input to the function is not of type InfiniteData; It's quite hard to infer the correct type, so making the function generic and defaulting to unknown is the safer choice. Users can now still explicitly provide the generic.

2) for all other methods on the queryClient, generics were mising and types for pages / allPages were always unknown. Adding a generic to refetchQueries / invalidateQueries / resetQueries that also defaults to unknown fixes that and makes those function easier to work with