### PR TITLE
fix(docs): fix markdown styles of links

### DIFF
--- a/docs/src/components/markdown.module.css
+++ b/docs/src/components/markdown.module.css
@@ -61,19 +61,19 @@
   @apply text-base;
 }
 
-.markdown > p > a,
-.markdown > ul > li > a,
-.markdown > ol > li > a,
-.markdown > blockquote > p > a,
-.markdown > table > tbody > tr > td > a {
+.markdown p > a,
+.markdown ul > li > a,
+.markdown ol > li > a,
+.markdown blockquote > p > a,
+.markdown table > tbody > tr > td > a {
   @apply text-blue-600 font-semibold transition-colors duration-150 ease-out;
 }
 
-.markdown > p > a:hover,
-.markdown > ul > li > a:hover,
-.markdown > ol > li > a:hover,
-.markdown > blockquote > p > a:hover,
-.markdown > table > tbody > tr > td > a:hover {
+.markdown p > a:hover,
+.markdown ul > li > a:hover,
+.markdown ol > li > a:hover,
+.markdown blockquote > p > a:hover,
+.markdown table > tbody > tr > td > a:hover {
   @apply text-blue-800 transition-colors duration-150 ease-out;
 }
 


### PR DESCRIPTION
Styles for links inside `li`s were not getting applied

**Before changes:** 
![image](https://user-images.githubusercontent.com/52021185/132303339-2a1307c1-31a7-4ebe-b4d4-dc6567c1fb9f.png)
**After changes:** 
![image](https://user-images.githubusercontent.com/52021185/132303099-27a40048-0fad-4aa9-8948-7a2f03e5ba42.png)
