### PR TITLE
fix(types): exclude queryKey / queryFn from options if they have been provided as a separate argument

### DIFF
--- a/src/react/useInfiniteQuery.ts
+++ b/src/react/useInfiniteQuery.ts
@@ -28,12 +28,15 @@ export function useInfiniteQuery<
   TQueryKey extends QueryKey = QueryKey
 >(
   queryKey: TQueryKey,
-  options?: UseInfiniteQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    TQueryKey
+  options?: Omit<
+    UseInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >,
+    'queryKey'
   >
 ): UseInfiniteQueryResult<TData, TError>
 export function useInfiniteQuery<
@@ -44,12 +47,15 @@ export function useInfiniteQuery<
 >(
   queryKey: TQueryKey,
   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-  options?: UseInfiniteQueryOptions<
-    TQueryFnData,
-    TError,
-    TData,
-    TQueryFnData,
-    TQueryKey
+  options?: Omit<
+    UseInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >,
+    'queryKey' | 'queryFn'
   >
 ): UseInfiniteQueryResult<TData, TError>
 export function useInfiniteQuery<

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -29,7 +29,10 @@ export function useMutation<
   TContext = unknown
 >(
   mutationFn: MutationFunction<TData, TVariables>,
-  options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationFn'
+  >
 ): UseMutationResult<TData, TError, TVariables, TContext>
 export function useMutation<
   TData = unknown,
@@ -38,7 +41,10 @@ export function useMutation<
   TContext = unknown
 >(
   mutationKey: MutationKey,
-  options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationKey'
+  >
 ): UseMutationResult<TData, TError, TVariables, TContext>
 export function useMutation<
   TData = unknown,
@@ -48,7 +54,10 @@ export function useMutation<
 >(
   mutationKey: MutationKey,
   mutationFn?: MutationFunction<TData, TVariables>,
-  options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, TContext>,
+    'mutationKey' | 'mutationFn'
+  >
 ): UseMutationResult<TData, TError, TVariables, TContext>
 export function useMutation<
   TData = unknown,

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -21,7 +21,10 @@ export function useQuery<
   TQueryKey extends QueryKey = QueryKey
 >(
   queryKey: TQueryKey,
-  options?: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey'
+  >
 ): UseQueryResult<TData, TError>
 export function useQuery<
   TQueryFnData = unknown,
@@ -31,7 +34,10 @@ export function useQuery<
 >(
   queryKey: TQueryKey,
   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-  options?: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+  options?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'queryKey' | 'queryFn'
+  >
 ): UseQueryResult<TData, TError>
 export function useQuery<
   TQueryFnData,


### PR DESCRIPTION
when using the overloaded version with multiple arguments, passing the same value inside options doesn't have any effect and is ignored at runtime, e.g.: `useQuery(key, fetchIt, { queryKey: 'foo' })`. With this fix, we disallow that on type level

closes #2647 