### PR TITLE
docs: Add side effects from using setQueryData

### DIFF
--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -205,6 +205,8 @@ This distinction is more a "convenience" for ts devs that know which structure w
 
 `setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook in the default `cacheTime` of 5 minutes, the query will be garbage collected**.
 
+After successful changing query's cached data via `setQueryData`, it will also trigger `onSuccess` callback from that query.
+
 > The difference between using `setQueryData` and `fetchQuery` is that `setQueryData` is sync and assumes that you already synchronously have the data available. If you need to fetch the data asynchronously, it's suggested that you either refetch the query key or use `fetchQuery` to handle the asynchronous fetch.
 
 ```js


### PR DESCRIPTION
Adding this information since I think it wasn't mentioned and may cause some confusion for other people.

Add side effects from using `setQueryData`.
I only know successful `setQueryData` will trigger `onSuccess` callback from that query, but if there is any more side effects that can be added, please let me know.

Thanks.