### PR TITLE
Missing batch updates on Production

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
   "types": "types/index.d.ts",
   "module": "es/index.js",
   "sideEffects": [
+    "es/index.js",
+    "es/react/index.js",
     "es/react/setBatchUpdatesFn.js",
     "es/react/setLogger.js",
+    "lib/index.js",
+    "lib/react/index.js",
     "lib/react/setBatchUpdatesFn.js",
     "lib/react/setLogger.js"
   ],


### PR DESCRIPTION
### Description

Currently development and production bundles have differences that affects React Query batching update. Changing `sideEffects` makes both `setBatchUpdatesFn` and `setLogger` to be included on final production bundle without affecting development. 

The thing here is to add index.js files to sideEffects as they calls the side effect directly. A similar code is available on webpack docs, which explains which files should be added there

### Summary

- fix(core): add index.js files to sideEffects

### Related issues

https://github.com/tannerlinsley/react-query/issues/2675
https://github.com/tannerlinsley/react-query/issues/2644