### PR TITLE
docs(devTools): Clarify node env logic for devtools

### DIFF
--- a/docs/src/pages/devtools.md
+++ b/docs/src/pages/devtools.md
@@ -17,8 +17,7 @@ The devtools are bundle split into the `react-query/devtools` package. No need t
 import { ReactQueryDevtools } from 'react-query/devtools'
 ```
 
-By default, React Query Devtools are not included in production bundles when `process.env.NODE_ENV === 'production'`, so you don't need to worry about excluding them during a production build.
-
+By default, React Query Devtools are only included in bundles when `process.env.NODE_ENV === 'development'`, so you don't need to worry about excluding them during a production build.
 ## Floating Mode
 
 Floating Mode will mount the devtools as a fixed, floating element in your app and provide a toggle in the corner of the screen to show and hide the devtools. This toggle state will be stored and remembered in localStorage across reloads.


### PR DESCRIPTION
I was struggling to understand why the devTools were not rendering in our application. The docs currently state that if `process.env.NODE_ENV === 'production'`, they will not be included in the build.

However, this is misleading, because the actual logic as [you can see here](https://github.com/tannerlinsley/react-query/blob/master/devtools/index.js) is to only include the devTools if `process.env.NODE_ENV === 'development'`.

In the app I was working on, during development, our `NODE_ENV` was actually set to `dev`. While I understand it's a convention in the node world to use `process.env.NODE_ENV === 'development'`, for whatever reason this app was setup slightly differently, and the docs were somewhat misleading here. Hopefully this should prevent someone else from experiencing the same confusion.