### PR TITLE
fix types of `UseQueryOptions`

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -91,7 +91,7 @@ export interface QueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryOptions<TQueryFnData, TError, TData, TQueryKey> {
+> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -91,7 +91,7 @@ export interface QueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
+> extends QueryOptions<TQueryFnData, TError, TData, TQueryKey> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.

--- a/src/react/tests/types.test.tsx
+++ b/src/react/tests/types.test.tsx
@@ -1,0 +1,13 @@
+import { InitialDataFunction, UseQueryOptions } from 'react-query'
+import { expectType } from './utils'
+
+test('initialData', () => {
+  type TOutput = 'output'
+  type MyQuery = UseQueryOptions<'input', Error, TOutput>
+
+  type TInitialData = MyQuery['initialData']
+
+  type TExpected = undefined | TOutput | InitialDataFunction<TOutput>
+
+  expectType<TExpected>((null as any) as TInitialData)
+})


### PR DESCRIPTION
In tRPC we extend `UseQueryOptions` like this

```tsx
interface UseTRPCQueryOptions<TInput, TError, TOutput>
  extends UseQueryOptions<TInput, TError, TOutput, QueryKey>,
    TRPCUseQueryBaseOptions {}
```

This leads to `initialData` being incorrectly typed as `TInput` instead of `TOutput` - see https://github.com/trpc/trpc/issues/990

I think this is the culprit.