### PR TITLE
fix(devtools): Default ReactQueryDevtoolsPanel isOpen to true

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -72,7 +72,7 @@ interface DevtoolsPanelOptions {
   /**
    * A boolean variable indicating whether the panel is open or closed
    */
-  isOpen: boolean
+  isOpen?: boolean
   /**
    * A function that toggles the open and close state of the panel
    */
@@ -365,7 +365,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef<
   HTMLDivElement,
   DevtoolsPanelOptions
 >(function ReactQueryDevtoolsPanel(props, ref): React.ReactElement {
-  const { isOpen, setIsOpen, handleDragStart, ...panelProps } = props
+  const { isOpen = true, setIsOpen, handleDragStart, ...panelProps } = props
 
   const queryClient = useQueryClient()
   const queryCache = queryClient.getQueryCache()


### PR DESCRIPTION
Change the `isOpen` prop for the ReactQueryDevtoolsPanel component to default
to true. The subscriptions aren't set up when no isOpen prop is passed, which makes
the panel not show any updates when used without the isOpen prop.

Closes #2745