### PR TITLE
expose `CancelOptions` & `SetDataOptions` 

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -15,12 +15,13 @@ import type {
   QueryFunctionContext,
   EnsuredQueryKey,
   QueryMeta,
+  CancelOptions,
 } from './types'
 import type { QueryCache } from './queryCache'
 import type { QueryObserver } from './queryObserver'
 import { notifyManager } from './notifyManager'
 import { getLogger } from './logger'
-import { Retryer, CancelOptions, isCancelledError } from './retryer'
+import { Retryer, isCancelledError } from './retryer'
 
 // TYPES
 

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -16,6 +16,7 @@ import type {
   EnsuredQueryKey,
   QueryMeta,
   CancelOptions,
+  SetDataOptions,
 } from './types'
 import type { QueryCache } from './queryCache'
 import type { QueryObserver } from './queryObserver'
@@ -83,10 +84,6 @@ export interface QueryBehavior<
 export interface FetchOptions {
   cancelRefetch?: boolean
   meta?: any
-}
-
-export interface SetDataOptions {
-  updatedAt?: number
 }
 
 interface FailedAction {

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -34,8 +34,8 @@ import { MutationCache } from './mutationCache'
 import { focusManager } from './focusManager'
 import { onlineManager } from './onlineManager'
 import { notifyManager } from './notifyManager'
-import { CancelOptions } from './retryer'
 import { infiniteQueryBehavior } from './infiniteQueryBehavior'
+import { CancelOptions } from './types'
 
 // TYPES
 

--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -27,8 +27,9 @@ import type {
   RefetchQueryFilters,
   ResetOptions,
   ResetQueryFilters,
+  SetDataOptions,
 } from './types'
-import type { QueryState, SetDataOptions } from './query'
+import type { QueryState } from './query'
 import { QueryCache } from './queryCache'
 import { MutationCache } from './mutationCache'
 import { focusManager } from './focusManager'

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -1,6 +1,7 @@
 import { focusManager } from './focusManager'
 import { onlineManager } from './onlineManager'
 import { sleep } from './utils'
+import { CancelOptions } from './types'
 
 // TYPES
 
@@ -39,11 +40,6 @@ interface Cancelable {
 
 export function isCancelable(value: any): value is Cancelable {
   return typeof value?.cancel === 'function'
-}
-
-export interface CancelOptions {
-  revert?: boolean
-  silent?: boolean
 }
 
 export class CancelledError {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -674,3 +674,7 @@ export interface CancelOptions {
   revert?: boolean
   silent?: boolean
 }
+
+export interface SetDataOptions {
+  updatedAt?: number
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -669,3 +669,8 @@ export interface DefaultOptions<TError = unknown> {
   queries?: QueryObserverOptions<unknown, TError>
   mutations?: MutationObserverOptions<unknown, TError, unknown, unknown>
 }
+
+export interface CancelOptions {
+  revert?: boolean
+  silent?: boolean
+}


### PR DESCRIPTION
Background: it would be nice if I didn't have to do [this](https://github.com/trpc/trpc/pull/1186#discussion_r738841851) :)

Technically, this is a breaking change - the other idea I had was to just expose these types in the `types.ts`-file but then the linter complained about circular dep.

It's hard structuring what is "internal" and what is "external" types - the way I go about it in tRPC is that I have folders called `internal/` in various places and I make sure to only cherry-pick from those, and they aren't cherry-picked I do `export *`