### PR TITLE
feat: add optional functions to serialize and deserialize from Storage Persistors

### DIFF
--- a/docs/src/pages/plugins/createAsyncStoragePersistor.md
+++ b/docs/src/pages/plugins/createAsyncStoragePersistor.md
@@ -60,6 +60,10 @@ interface CreateAsyncStoragePersistorOptions {
   /** To avoid localstorage spamming,
    * pass a time in ms to throttle saving the cache to disk */
   throttleTime?: number
+  /** How to serialize the data to storage */
+  serialize?: (client: PersistedClient) => string
+  /** How to deserialize the data from storage */
+  deserialize?: (cachedString: string) => PersistedClient
 }
 
 interface AsyncStorage {
@@ -75,5 +79,7 @@ The default options are:
 {
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
+  serialize = JSON.stringify,
+  deserialize = JSON.parse,
 }
 ```

--- a/docs/src/pages/plugins/createWebStoragePersistor.md
+++ b/docs/src/pages/plugins/createWebStoragePersistor.md
@@ -57,6 +57,10 @@ interface CreateWebStoragePersistorOptions {
   /** To avoid spamming,
    * pass a time in ms to throttle saving the cache to disk */
   throttleTime?: number
+  /** How to serialize the data to storage */
+  serialize?: (client: PersistedClient) => string
+  /** How to deserialize the data from storage */
+  deserialize?: (cachedString: string) => PersistedClient
 }
 ```
 
@@ -66,5 +70,7 @@ The default options are:
 {
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
+  serialize = JSON.stringify,
+  deserialize = JSON.parse,
 }
 ```

--- a/src/createAsyncStoragePersistor-experimental/index.ts
+++ b/src/createAsyncStoragePersistor-experimental/index.ts
@@ -14,16 +14,28 @@ interface CreateAsyncStoragePersistorOptions {
   /** To avoid spamming,
    * pass a time in ms to throttle saving the cache to disk */
   throttleTime?: number
+  /**
+   * How to serialize the data to storage.
+   * @default `JSON.stringify`
+   */
+  serialize?: (client: PersistedClient) => string
+  /**
+   * How to deserialize the data from storage.
+   * @default `JSON.parse`
+   */
+  deserialize?: (cachedString: string) => PersistedClient
 }
 
 export const createAsyncStoragePersistor = ({
   storage,
   key = `REACT_QUERY_OFFLINE_CACHE`,
   throttleTime = 1000,
+  serialize = JSON.stringify,
+  deserialize = JSON.parse,
 }: CreateAsyncStoragePersistorOptions): Persistor => {
   return {
     persistClient: asyncThrottle(
-      persistedClient => storage.setItem(key, JSON.stringify(persistedClient)),
+      persistedClient => storage.setItem(key, serialize(persistedClient)),
       { interval: throttleTime }
     ),
     restoreClient: async () => {
@@ -33,7 +45,7 @@ export const createAsyncStoragePersistor = ({
         return
       }
 
-      return JSON.parse(cacheString) as PersistedClient
+      return deserialize(cacheString) as PersistedClient
     },
     removeClient: () => storage.removeItem(key),
   }

--- a/src/createAsyncStoragePersistor-experimental/index.ts
+++ b/src/createAsyncStoragePersistor-experimental/index.ts
@@ -51,16 +51,16 @@ export const createAsyncStoragePersistor = ({
   }
 }
 
-function asyncThrottle<T>(
-  func: (...args: ReadonlyArray<unknown>) => Promise<T>,
+function asyncThrottle<Args extends readonly unknown[], Result>(
+  func: (...args: Args) => Promise<Result>,
   { interval = 1000, limit = 1 }: { interval?: number; limit?: number } = {}
 ) {
   if (typeof func !== 'function') throw new Error('argument is not function.')
   const running = { current: false }
   let lastTime = 0
   let timeout: number
-  const queue: Array<any[]> = []
-  return (...args: any) =>
+  const queue: Array<Args> = []
+  return (...args: Args) =>
     (async () => {
       if (running.current) {
         lastTime = Date.now()


### PR DESCRIPTION
Right now the (experimental) persistor functionality or at least the two built-in ones use simple JSON `stringify` and `parse`.
This is fine, but I'd like to get some more control over the serialization and deserialization of the data.
For example, the data I store in `react-query`'s cache is already JS objects which are not valid JSON in some cases - e.g. `Date` reviving upon `fetch`ing from the server:
```js
const data = fetch('https://my-api.com')
  .then(response => response.text())
  .then(text => JSON.parse(text, dateReviver); // see https://gist.github.com/davehax/2f32e7b09c3da3531601e6543fcff82e for an example for a `dateReviver` implementation
```

More details in https://github.com/tannerlinsley/react-query/discussions/2771