### PR TITLE
fix(useQueries): search for unused observers if keepPreviousData (#2680)

### DIFF
--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -77,17 +77,17 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     const newObservers: QueryObserver[] = []
     const newObserversMap: Record<string, QueryObserver> = {}
 
-    const defaultedQueryOptions = queries.map(o =>
-      this.client.defaultQueryObserverOptions(o)
+    const defaultedQueryOptions = queries.map(options =>
+      this.client.defaultQueryObserverOptions(options)
     )
     const matchingObservers = defaultedQueryOptions
-      .map(o => {
-        if (o.queryHash == null) {
+      .map(options => {
+        if (options.queryHash == null) {
           return null
         }
-        const match = prevObserversMap[o.queryHash]
+        const match = prevObserversMap[options.queryHash]
         if (match != null) {
-          match.setOptions(o, notifyOptions)
+          match.setOptions(options, notifyOptions)
           return match
         }
         return null
@@ -95,27 +95,28 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       .filter(notNullOrUndefined)
 
     const matchedQueryHashes = matchingObservers
-      .map(o => o?.options.queryHash)
+      .map(observer => observer?.options.queryHash)
       .filter(notNullOrUndefined)
     const unmatchedQueries = defaultedQueryOptions.filter(
-      o =>
-        o.queryHash !== undefined && !matchedQueryHashes.includes(o.queryHash)
+      options =>
+        options.queryHash !== undefined &&
+        !matchedQueryHashes.includes(options.queryHash)
     )
 
     const unmatchedObservers = prevObservers.filter(
-      p => !matchingObservers.includes(p)
+      prevObserver => !matchingObservers.includes(prevObserver)
     )
 
-    const newlyMatchedOrCreatedObservers = unmatchedQueries.map(q => {
-      if (q.keepPreviousData && unmatchedObservers.length > 0) {
-        // use the first existing but no longer matched query to keep query data for any new queries
+    const newlyMatchedOrCreatedObservers = unmatchedQueries.map(options => {
+      if (options.keepPreviousData && unmatchedObservers.length > 0) {
+        // use the first observer but no longer matched query to keep query data for any new queries
         const firstObserver = unmatchedObservers.splice(0, 1)[0]
         if (firstObserver !== undefined) {
-          firstObserver.setOptions(q, notifyOptions)
+          firstObserver.setOptions(options, notifyOptions)
           return firstObserver
         }
       }
-      return this.getObserver(q)
+      return this.getObserver(options)
     })
 
     matchingObservers
@@ -148,7 +149,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       )
 
       const hasIndexChange = updatedObservers.newObservers.some(
-        (o, i) => o !== prevObservers[i]
+        (observer, index) => observer !== prevObservers[index]
       )
       if (
         prevObservers.length === updatedObservers.newObservers.length &&

--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -1,4 +1,4 @@
-import { difference, notNullOrUndefined, replaceAt } from './utils'
+import { difference, replaceAt } from './utils'
 import { notifyManager } from './notifyManager'
 import type { QueryObserverOptions, QueryObserverResult } from './types'
 import type { QueryClient } from './queryClient'
@@ -77,17 +77,17 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       this.client.defaultQueryObserverOptions(options)
     )
 
-    const matchingObservers: QueryObserverMatch[] = defaultedQueryOptions
-      .map(defaultedOptions => {
+    const matchingObservers: QueryObserverMatch[] = defaultedQueryOptions.flatMap(
+      defaultedOptions => {
         const match = prevObservers.find(
-          observer => observer.options.queryHash === defaultedOptions.queryHash!
+          observer => observer.options.queryHash === defaultedOptions.queryHash
         )
         if (match != null) {
-          return { defaultedQueryOptions: defaultedOptions, observer: match }
+          return [{ defaultedQueryOptions: defaultedOptions, observer: match }]
         }
-        return null
-      })
-      .filter(notNullOrUndefined)
+        return []
+      }
+    )
 
     const matchedQueryHashes = matchingObservers.map(
       match => match.defaultedQueryOptions.queryHash
@@ -104,7 +104,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
 
     const newOrReusedObservers: QueryObserverMatch[] = unmatchedQueries.map(
       (options, index) => {
-        if (options.keepPreviousData && unmatchedObservers.length > 0) {
+        if (options.keepPreviousData) {
           // return previous data from one of the observers that no longer match
           const previouslyUsedObserver = unmatchedObservers[index]
           if (previouslyUsedObserver !== undefined) {

--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -82,10 +82,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     )
     const matchingObservers = defaultedQueryOptions
       .map(options => {
-        if (options.queryHash == null) {
-          return null
-        }
-        const match = prevObserversMap[options.queryHash]
+        const match = prevObserversMap[options.queryHash ?? '']
         if (match != null) {
           match.setOptions(options, notifyOptions)
           return match
@@ -94,13 +91,11 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       })
       .filter(notNullOrUndefined)
 
-    const matchedQueryHashes = matchingObservers
-      .map(observer => observer?.options.queryHash)
-      .filter(notNullOrUndefined)
+    const matchedQueryHashes = matchingObservers.map(
+      observer => observer?.options.queryHash
+    )
     const unmatchedQueries = defaultedQueryOptions.filter(
-      options =>
-        options.queryHash !== undefined &&
-        !matchedQueryHashes.includes(options.queryHash)
+      options => !matchedQueryHashes.includes(options.queryHash)
     )
 
     const unmatchedObservers = prevObservers.filter(
@@ -124,7 +119,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       .forEach(observer => {
         newObservers.push(observer)
         newResult.push(observer.getCurrentResult())
-        newObserversMap[observer.options.queryHash!] = observer
+        newObserversMap[observer.options.queryHash ?? ''] = observer
       })
 
     return {

--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -82,7 +82,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
     )
     const matchingObservers = defaultedQueryOptions
       .map(options => {
-        const match = prevObserversMap[options.queryHash ?? '']
+        const match = prevObserversMap[options.queryHash!]
         if (match != null) {
           match.setOptions(options, notifyOptions)
           return match
@@ -119,7 +119,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       .forEach(observer => {
         newObservers.push(observer)
         newResult.push(observer.getCurrentResult())
-        newObserversMap[observer.options.queryHash ?? ''] = observer
+        newObserversMap[observer.options.queryHash!] = observer
       })
 
     return {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -457,6 +457,6 @@ export function getAbortController(): AbortController | undefined {
 /**
  * Type predicate to filter an array of null or undefined elements
  */
-export function notNullOrUndefined<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined;
+export function notNullOrUndefined<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -453,3 +453,10 @@ export function getAbortController(): AbortController | undefined {
     return new AbortController()
   }
 }
+
+/**
+ * Type predicate to filter an array of null or undefined elements
+ */
+export function notNullOrUndefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -453,10 +453,3 @@ export function getAbortController(): AbortController | undefined {
     return new AbortController()
   }
 }
-
-/**
- * Type predicate to filter an array of null or undefined elements
- */
-export function notNullOrUndefined<T>(value: T): value is NonNullable<T> {
-  return value !== null && value !== undefined
-}

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -98,7 +98,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(8))
+    await waitFor(() => expect(states.length).toBe(7))
 
     expect(states[0]).toMatchObject([
       {
@@ -128,22 +128,18 @@ describe('useQueries', () => {
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
     ])
     expect(states[3]).toMatchObject([
-      { status: 'success', data: 2, isPreviousData: true, isFetching: true },
-      { status: 'success', data: 5, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 2, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
     ])
     expect(states[4]).toMatchObject([
       { status: 'success', data: 2, isPreviousData: true, isFetching: true },
       { status: 'success', data: 5, isPreviousData: true, isFetching: true },
     ])
     expect(states[5]).toMatchObject([
-      { status: 'success', data: 2, isPreviousData: true, isFetching: true },
-      { status: 'success', data: 5, isPreviousData: true, isFetching: true },
-    ])
-    expect(states[6]).toMatchObject([
       { status: 'success', data: 4, isPreviousData: false, isFetching: false },
       { status: 'success', data: 5, isPreviousData: true, isFetching: true },
     ])
-    expect(states[7]).toMatchObject([
+    expect(states[6]).toMatchObject([
       { status: 'success', data: 4, isPreviousData: false, isFetching: false },
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
@@ -179,7 +175,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(10))
+    await waitFor(() => expect(states.length).toBe(8))
 
     expect(states[0]).toMatchObject([
       {
@@ -210,8 +206,8 @@ describe('useQueries', () => {
     ])
 
     expect(states[3]).toMatchObject([
-      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
-      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 4, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 8, isPreviousData: false, isFetching: false },
       {
         status: 'loading',
         data: undefined,
@@ -230,7 +226,7 @@ describe('useQueries', () => {
       },
     ])
     expect(states[5]).toMatchObject([
-      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
       { status: 'success', data: 8, isPreviousData: true, isFetching: true },
       {
         status: 'loading',
@@ -240,26 +236,6 @@ describe('useQueries', () => {
       },
     ])
     expect(states[6]).toMatchObject([
-      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
-      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
-      {
-        status: 'loading',
-        data: undefined,
-        isPreviousData: false,
-        isFetching: true,
-      },
-    ])
-    expect(states[7]).toMatchObject([
-      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
-      {
-        status: 'loading',
-        data: undefined,
-        isPreviousData: false,
-        isFetching: true,
-      },
-    ])
-    expect(states[8]).toMatchObject([
       { status: 'success', data: 6, isPreviousData: false, isFetching: false },
       { status: 'success', data: 12, isPreviousData: false, isFetching: false },
       {
@@ -269,7 +245,7 @@ describe('useQueries', () => {
         isFetching: true,
       },
     ])
-    expect(states[9]).toMatchObject([
+    expect(states[7]).toMatchObject([
       { status: 'success', data: 6, isPreviousData: false, isFetching: false },
       { status: 'success', data: 12, isPreviousData: false, isFetching: false },
       { status: 'success', data: 18, isPreviousData: false, isFetching: false },
@@ -317,7 +293,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(12))
+    await waitFor(() => expect(states.length).toBe(10))
 
     expect(states[0]).toMatchObject([
       {
@@ -348,7 +324,7 @@ describe('useQueries', () => {
     ])
     expect(states[3]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 10, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
     expect(states[4]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
@@ -359,26 +335,18 @@ describe('useQueries', () => {
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[6]).toMatchObject([
-      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
     ])
     expect(states[7]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[8]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[9]).toMatchObject([
-      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
-    ])
-    expect(states[10]).toMatchObject([
-      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
-    ])
-    expect(states[11]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -98,7 +98,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(7))
+    await waitFor(() => expect(states.length).toBe(8))
 
     expect(states[0]).toMatchObject([
       {
@@ -136,10 +136,14 @@ describe('useQueries', () => {
       { status: 'success', data: 5, isPreviousData: true, isFetching: true },
     ])
     expect(states[5]).toMatchObject([
-      { status: 'success', data: 4, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 2, isPreviousData: true, isFetching: true },
       { status: 'success', data: 5, isPreviousData: true, isFetching: true },
     ])
     expect(states[6]).toMatchObject([
+      { status: 'success', data: 4, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 5, isPreviousData: true, isFetching: true },
+    ])
+    expect(states[7]).toMatchObject([
       { status: 'success', data: 4, isPreviousData: false, isFetching: false },
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
@@ -175,7 +179,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(8))
+    await waitFor(() => expect(states.length).toBe(10))
 
     expect(states[0]).toMatchObject([
       {
@@ -226,7 +230,7 @@ describe('useQueries', () => {
       },
     ])
     expect(states[5]).toMatchObject([
-      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
       { status: 'success', data: 8, isPreviousData: true, isFetching: true },
       {
         status: 'loading',
@@ -236,8 +240,8 @@ describe('useQueries', () => {
       },
     ])
     expect(states[6]).toMatchObject([
-      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 12, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
       {
         status: 'loading',
         data: undefined,
@@ -247,8 +251,136 @@ describe('useQueries', () => {
     ])
     expect(states[7]).toMatchObject([
       { status: 'success', data: 6, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
+      {
+        status: 'loading',
+        data: undefined,
+        isPreviousData: false,
+        isFetching: true,
+      },
+    ])
+    expect(states[8]).toMatchObject([
+      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 12, isPreviousData: false, isFetching: false },
+      {
+        status: 'loading',
+        data: undefined,
+        isPreviousData: false,
+        isFetching: true,
+      },
+    ])
+    expect(states[9]).toMatchObject([
+      { status: 'success', data: 6, isPreviousData: false, isFetching: false },
       { status: 'success', data: 12, isPreviousData: false, isFetching: false },
       { status: 'success', data: 18, isPreviousData: false, isFetching: false },
+    ])
+  })
+
+  it('should keep previous data when switching between queries', async () => {
+    const key = queryKey()
+    const states: UseQueryResult[][] = []
+
+    function Page() {
+      const [series1, setSeries1] = React.useState(1)
+      const [series2, setSeries2] = React.useState(2)
+      const ids = [series1, series2]
+
+      const result = useQueries(
+        ids.map(id => {
+          return {
+            queryKey: [key, id],
+            queryFn: async () => {
+              await sleep(5)
+              return id * 5
+            },
+            keepPreviousData: true,
+          }
+        })
+      )
+
+      states.push(result)
+
+      React.useEffect(() => {
+        setActTimeout(() => {
+          setSeries2(3)
+        }, 20)
+      }, [])
+
+      React.useEffect(() => {
+        setActTimeout(() => {
+          setSeries1(2)
+        }, 50)
+      }, [])
+
+      return null
+    }
+
+    renderWithClient(queryClient, <Page />)
+
+    await waitFor(() => expect(states.length).toBe(12))
+
+    expect(states[0]).toMatchObject([
+      {
+        status: 'loading',
+        data: undefined,
+        isPreviousData: false,
+        isFetching: true,
+      },
+      {
+        status: 'loading',
+        data: undefined,
+        isPreviousData: false,
+        isFetching: true,
+      },
+    ])
+    expect(states[1]).toMatchObject([
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      {
+        status: 'loading',
+        data: undefined,
+        isPreviousData: false,
+        isFetching: true,
+      },
+    ])
+    expect(states[2]).toMatchObject([
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
+    ])
+    expect(states[3]).toMatchObject([
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 10, isPreviousData: true, isFetching: true },
+    ])
+    expect(states[4]).toMatchObject([
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 10, isPreviousData: true, isFetching: true },
+    ])
+    expect(states[5]).toMatchObject([
+      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
+    ])
+    expect(states[6]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+    ])
+    expect(states[7]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+    ])
+    expect(states[8]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+    ])
+    expect(states[9]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+    ])
+    expect(states[10]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: true },
+    ])
+    expect(states[11]).toMatchObject([
+      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
   })
 


### PR DESCRIPTION
#closes 2680

When `keepPreviousData` is on, search for a query observer no longer used instead of relying on observer order and indexing. Trying to match observers by index could cause infinite request loops when switching queries. See #2680 for more 

This does complicate the `getOptimisticResult` and `updateObservers` calls a bit. Now they both essentially do the same search for unused observers. The observers lists for the `queriesObserver` are only updated in the `updateObservers`, though. 

This does cause some extra updates, as can be seen in the tests. If I understand correctly, they probably are due to the `setOptions` calls being called both on `getOptimisticResult` and `updateObservers` calls. I tried for quite a while to get rid of the extra updates, but couldn't find a way that would still always return previous data, so eventually just left it like this and edited the tests. Any ideas to get rid of the extra updates are very welcome 😊 
