### PR TITLE
Fix progressively smaller font size for Explorer

### DIFF
--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -6,7 +6,7 @@ import { styled } from './utils'
 
 export const Entry = styled('div', {
   fontFamily: 'Menlo, monospace',
-  fontSize: '0.9em',
+  fontSize: '1em',
   lineHeight: '1.7',
   outline: 'none',
   wordBreak: 'break-word',


### PR DESCRIPTION
Resolved bug mentioned in this [comment](https://github.com/tannerlinsley/react-query/pull/2760#issuecomment-961812722)
Fix progressively smaller font size for Explorer entries in devtools
Set Entry font-size to 1em, because it is indented multiple time within each other.
This causes the font to get smaller and smaller as `em` is relative to the parent font size.
<img width="977" alt="font-size-progressively-smaller" src="https://user-images.githubusercontent.com/2103443/140532373-31a341a5-be29-466b-812f-0567d4680b6f.png">

