### PR TITLE
fix(useQuery): make sure that disabled queries in error state don't throw

### DIFF
--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -131,6 +131,7 @@ export function useBaseQuery<
   // Handle error boundary
   if (
     result.isError &&
+    defaultedOptions.enabled !== false &&
     !result.isFetching &&
     shouldThrowError(
       defaultedOptions.suspense,


### PR DESCRIPTION
fixes #2930 

one caveat is that the disabled query will be rendered with `status: 'error'`, because that's the state the query is in. Usually, with `useErrorBoundary`, you'd expect to _never_ see a query in error state. However, I think disabled queries can be in all resolved states (success, error, idle), so if you use `enabled`, that's what you get. This behaviour is documented with a separate test.