### PR TITLE
Add pitfall case for hydration with Next.js' Incremental Static Regeneration to the docs

### DIFF
--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -124,9 +124,9 @@ gets created once per revalidation cycle. This means that the internal timer of 
 Let's imagine in our example (5 minutes revalidation cycle and 3 minutes stale time), a request is sent at minute 4 of the revalidation cycle.
 Next.js does not need to revalidate again (because it's less than 5 minutes), so it sends the already existent client with the running `staleTime` timer.
 The query is considered stale after 3 minutes, our request comes in after 4 minutes, so React Query wants to refetch.
+
 The pitfall: This refetching will not happen in `getStaticProps` automatically, because the query is not "used" on the server.
-Rather, Next.js sends the existing client to the browser with it's data like it always does. The client therefore has the existing data
-of the last revalidation cycle and can use it for hydration.
+Rather, Next.js sends the existing client to the browser with its data like it always does. The client therefore has the existing data of the last revalidation cycle and can use it for hydration.
 But: This query will immediately refetch in the browser, because the `staleTime` was reached, even though the data is there.
 
 ## Using Other Frameworks or Custom SSR Frameworks

--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -112,7 +112,7 @@ As demonstrated, it's fine to prefetch some queries and let others fetch on the 
 Please read the [general tips for this topic](#staleness-is-measured-from-when-the-query-was-fetched-on-the-server) first.
 
 You will need to synchronize your `getStaticProps` revalidation time (via `revalidate`) and the `staleTime` of your query.
-We have to do this, because otherwise it would prevent us from using the static page of Next.js' revalidation result otherwise.
+We have to do this, because otherwise it would prevent us from using the static page of Next.js' revalidation result.
 
 Via `getStaticProps`, we hydrate the query state with fresh data every revalidation cycle.
 Let's say revalidation is configured to be every 5 minutes. After 5 minutes, `getStaticProps` is executed again when a new user request comes in.

--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -112,7 +112,7 @@ As demonstrated, it's fine to prefetch some queries and let others fetch on the 
 Please read the [general tips for this topic](#staleness-is-measured-from-when-the-query-was-fetched-on-the-server) first.
 
 You will need to synchronize your `getStaticProps` revalidation time (via `revalidate`) and the `staleTime` of your query.
-We have to do this, because otherwise it would prevent us from using the static page of Next.js' revalidation result.
+Without the synchronization, it would prevent us from using the static page & the data to hydrate of Next.js' revalidation result.  
 
 Via `getStaticProps`, we hydrate the query state with fresh data every revalidation cycle.
 Let's say revalidation is configured to be every 5 minutes. After 5 minutes, `getStaticProps` is executed again when a new user request comes in.

--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -114,7 +114,7 @@ Please read the [general tips for this topic](#staleness-is-measured-from-when-t
 You will need to synchronize your `getStaticProps` revalidation time (via `revalidate`) and the `staleTime` of your query.
 We have to do this, because otherwise it would prevent us from using the static page of Next.js' revalidation result otherwise.
 
-Via `getStaticProps`, we hydrate the query state with fresh data every revlidation cycle.
+Via `getStaticProps`, we hydrate the query state with fresh data every revalidation cycle.
 Let's say revalidation is configured to be every 5 minutes. After 5 minutes, `getStaticProps` is executed again when a new user request comes in.
 But everything inbetween these 5 minutes, the "old" props result will be sent to the client.
 

--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -127,7 +127,7 @@ The query is considered stale after 3 minutes, our request comes in after 4 minu
 The pitfall: This refetching will not happen in `getStaticProps` automatically, because the query is not "used" on the server.
 Rather, Next.js sends the existing client to the browser with it's data like it always does. The client therefore has the existing data
 of the last revalidation cycle and can use it for hydration.
-But: The client will immediately refetch this query, because the `staleTime` was reached.
+But: This query will immediately refetch in the browser, because the `staleTime` was reached, even though the data is there.
 
 ## Using Other Frameworks or Custom SSR Frameworks
 


### PR DESCRIPTION
This change will add a pitfall for hydration with Next.js' Incremental Static Regeneration to the docs.

One thing I'm not sure about: How would you like to link to another paragraph on the same page? In this commit, I do it like this:

`Please read the [general tips for this topic](#staleness-is-measured-from-when-the-query-was-fetched-on-the-server) first.`

Feel free to change the text based on your preferences, I just think having this pitfall in the docs is valuable, because I stumbled upon this issue and it took me a long time to figure out what was going on.

---

_Here is the full text for reference:_

Please read the [general tips for this topic](#staleness-is-measured-from-when-the-query-was-fetched-on-the-server) first.

You will need to synchronize your `getStaticProps` revalidation time (via `revalidate`) and the `staleTime` of your query.
Without the synchronization, it would prevent us from using the static page & the data to hydrate of Next.js' revalidation result.

Via `getStaticProps`, we hydrate the query state with fresh data every revalidation cycle.
Let's say revalidation is configured to be every 5 minutes. After 5 minutes, `getStaticProps` is executed again when a new user request comes in.
But everything inbetween these 5 minutes, the "old" props result will be sent to the client.

Now, let's say a query has a `staleTime` of 3 minutes. This means, that React Query wants to refetch a query after 3 minutes (under most circumstances).
This stale time is bound to the query and the query is bound to the query client. We create the client in `getStaticProps`, which only
gets created once per revalidation cycle. This means that the internal timer of `staleTime` will continue to run.
Let's imagine in our example (5 minutes revalidation cycle and 3 minutes stale time), a request is sent at minute 4 of the revalidation cycle.
Next.js does not need to revalidate again (because it's less than 5 minutes), so it sends the already existent client with the running `staleTime` timer.
The query is considered stale after 3 minutes, our request comes in after 4 minutes, so React Query wants to refetch.
The pitfall: This refetching will not happen in `getStaticProps` automatically, because the query is not "used" on the server.
Rather, Next.js sends the existing client to the browser with it's data like it always does. The client therefore has the existing data
of the last revalidation cycle and can use it for hydration.
But: This query will immediately refetch in the browser, because the `staleTime` was reached, even though the data is there.