### PR TITLE
fix(useQuery): don't throw error if errorBoundary has just been reset

### DIFF
--- a/src/react/useBaseQuery.ts
+++ b/src/react/useBaseQuery.ts
@@ -131,7 +131,7 @@ export function useBaseQuery<
   // Handle error boundary
   if (
     result.isError &&
-    defaultedOptions.enabled !== false &&
+    !errorResetBoundary.isReset() &&
     !result.isFetching &&
     shouldThrowError(
       defaultedOptions.suspense,


### PR DESCRIPTION
the fix for disabled queries was wrong, because disabled queries still need to throw if they are fetching due to some other means, like `refetch`. However, if a query has just been reset, we want to skip throwing for one render cycle. The useEffect that clears the reset will then make sure that further errors will be thrown