### PR TITLE
docs(cancel): add graphql-request example

### DIFF
--- a/docs/src/pages/guides/query-cancellation.md
+++ b/docs/src/pages/guides/query-cancellation.md
@@ -97,6 +97,19 @@ const query = useQuery('todos', ({ signal }) => {
 })
 ```
 
+## Using `graphql-request`
+
+An `AbortSignal` can be set in the `GraphQLClient` constructor.
+
+```js
+const query = useQuery('todos', ({ signal }) => {
+  const client = new GraphQLClient(endpoint, {
+    signal,
+  });
+  return client.request(query, variables)
+})
+```
+
 ## Manual Cancellation
 
 You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries(key)`, which will cancel the query and revert it back to its previous state. If `promise.cancel` is available, or you have consumed the `signal` passed to the query function, React Query will additionally also cancel the Promise.


### PR DESCRIPTION
It is possible to set an `AbortSignal` in the `GraphQLClient` constructor.

```js
const query = useQuery('todos', ({ signal }) => {
  const client = new GraphQLClient(endpoint, {
    signal,
  });
  return client.request(query, variables)
})
```

But unfortunately, it is not possible to define a `signal` per request:
https://github.com/prisma-labs/graphql-request/issues/182

It means that the GraphQL Code Gen React Query plugin cannot support a `signal` for the moment with graphql-request :pensive:

The solution is to:
- PR graphql-request to support a signal per request
- PR GraphQL Code Gen React Query Plugin to send the signal to the graphql-request request.



