### PR TITLE
refactor: Remove deprecated promise cancel

### DIFF
--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -148,6 +148,10 @@ Since these plugins are no longer experimental, their import paths have also bee
 + import { createAsyncStoragePersister } from 'react-query/createAsyncStoragePersister'
 ```
 
+### The `cancel` method on promises is no longer supported
+
+The [old `cancel` method](/query-cancellation#old-cancel-function) that allowed you to define a `cancel` function on promises which were then used by the library to support query cancellation has been removed. We recommend you to use the [newer API](/query-cancellation) (introduced with v3.30.0) for query cancellation that uses the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) internally and provides you with an [`AbortSignal` instance](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for your query function to support query cancellation.
+
 ## New Features 🚀
 
 ### Mutation Cache Garbage Collection

--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -150,7 +150,7 @@ Since these plugins are no longer experimental, their import paths have also bee
 
 ### The `cancel` method on promises is no longer supported
 
-The [old `cancel` method](../guides/query-cancellation#old-cancel-function) that allowed you to define a `cancel` function on promises which were then used by the library to support query cancellation has been removed. We recommend you to use the [newer API](../guides/query-cancellation) (introduced with v3.30.0) for query cancellation that uses the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) internally and provides you with an [`AbortSignal` instance](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for your query function to support query cancellation.
+The [old `cancel` method](../guides/query-cancellation#old-cancel-function) that allowed you to define a `cancel` function on promises, which was then used by the library to support query cancellation, has been removed. We recommend to use the [newer API](../guides/query-cancellation) (introduced with v3.30.0) for query cancellation that uses the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) internally and provides you with an [`AbortSignal` instance](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for your query function to support query cancellation.
 
 ## New Features 🚀
 

--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -150,7 +150,7 @@ Since these plugins are no longer experimental, their import paths have also bee
 
 ### The `cancel` method on promises is no longer supported
 
-The [old `cancel` method](/query-cancellation#old-cancel-function) that allowed you to define a `cancel` function on promises which were then used by the library to support query cancellation has been removed. We recommend you to use the [newer API](/query-cancellation) (introduced with v3.30.0) for query cancellation that uses the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) internally and provides you with an [`AbortSignal` instance](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for your query function to support query cancellation.
+The [old `cancel` method](../guides/query-cancellation#old-cancel-function) that allowed you to define a `cancel` function on promises which were then used by the library to support query cancellation has been removed. We recommend you to use the [newer API](../guides/query-cancellation) (introduced with v3.30.0) for query cancellation that uses the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) internally and provides you with an [`AbortSignal` instance](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for your query function to support query cancellation.
 
 ## New Features 🚀
 

--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -144,10 +144,9 @@ export function infiniteQueryBehavior<
         }))
 
         context.signal?.addEventListener('abort', () => {
-          cancelled = true;
+          cancelled = true
           abortController?.abort()
         })
-        
 
         return finalPromise
       }

--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -143,12 +143,11 @@ export function infiniteQueryBehavior<
           pageParams: newPageParams,
         }))
 
-        const finalPromiseAsAny = finalPromise as any
-
-        finalPromiseAsAny.cancel = () => {
-          cancelled = true
+        context.signal?.addEventListener('abort', () => {
+          cancelled = true;
           abortController?.abort()
-        }
+        })
+        
 
         return finalPromise
       }

--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -1,5 +1,5 @@
 import type { QueryBehavior } from './query'
-import { isCancelable } from './retryer'
+
 import type {
   InfiniteData,
   QueryFunctionContext,
@@ -72,11 +72,6 @@ export function infiniteQueryBehavior<
           const promise = Promise.resolve(queryFnResult).then(page =>
             buildNewPages(pages, param, page, previous)
           )
-
-          if (isCancelable(queryFnResult)) {
-            const promiseAsAny = promise as any
-            promiseAsAny.cancel = queryFnResult.cancel
-          }
 
           return promise
         }
@@ -153,9 +148,6 @@ export function infiniteQueryBehavior<
         finalPromiseAsAny.cancel = () => {
           cancelled = true
           abortController?.abort()
-          if (isCancelable(promise)) {
-            promise.cancel()
-          }
         }
 
         return finalPromise

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -383,16 +383,23 @@ export class Query<
       meta: this.meta,
     }
 
-    Object.defineProperty(queryFnContext, 'signal', {
-      enumerable: true,
-      get: () => {
-        if (abortController) {
-          this.abortSignalConsumed = true
-          return abortController.signal
-        }
-        return undefined
-      },
-    })
+    // Adds an enumerable signal property to the object that
+    // which sets abortSignalConsumed to true when the signal
+    // is read.
+    const addSignalProperty = (object: unknown) => {
+      Object.defineProperty(object, 'signal', {
+        enumerable: true,
+        get: () => {
+          if (abortController) {
+            this.abortSignalConsumed = true
+            return abortController.signal
+          }
+          return undefined
+        },
+      })
+    }
+
+    addSignalProperty(queryFnContext)
 
     // Create fetch function
     const fetchFn = () => {
@@ -413,16 +420,7 @@ export class Query<
       meta: this.meta,
     }
 
-    Object.defineProperty(context, 'signal', {
-      enumerable: true,
-      get: () => {
-        if (abortController) {
-          this.abortSignalConsumed = true
-          return abortController.signal
-        }
-        return undefined
-      },
-    })
+    addSignalProperty(context)
 
     if (this.options.behavior?.onFetch) {
       this.options.behavior?.onFetch(context)

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -144,6 +144,13 @@ export class Retryer<TData = unknown, TError = unknown> {
           reject(new CancelledError(cancelOptions))
 
           this.abort?.()
+
+          // Cancel transport if supported
+          if (isCancelable(promiseOrValue)) {
+            try {
+              promiseOrValue.cancel()
+            } catch {}
+          }
         }
       }
 

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -136,7 +136,6 @@ export class Retryer<TData = unknown, TError = unknown> {
         }
       }
 
-
       Promise.resolve(promiseOrValue)
         .then(resolve)
         .catch(error => {

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -144,13 +144,6 @@ export class Retryer<TData = unknown, TError = unknown> {
           reject(new CancelledError(cancelOptions))
 
           this.abort?.()
-
-          // Cancel transport if supported
-          if (isCancelable(promiseOrValue)) {
-            try {
-              promiseOrValue.cancel()
-            } catch {}
-          }
         }
       }
 

--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -329,43 +329,6 @@ describe('query', () => {
     expect(isCancelledError(error)).toBe(true)
   })
 
-  test('should call cancel() fn if it was provided and not continue when last observer unsubscribed', async () => {
-    const key = queryKey()
-
-    const cancel = jest.fn()
-
-    queryClient.prefetchQuery(key, async () => {
-      const promise = new Promise((resolve, reject) => {
-        sleep(100).then(() => resolve('data'))
-        cancel.mockImplementation(() => {
-          reject(new Error('Cancelled'))
-        })
-      }) as any
-      promise.cancel = cancel
-      return promise
-    })
-
-    await sleep(10)
-
-    // Subscribe and unsubscribe to simulate cancellation because the last observer unsubscribed
-    const observer = new QueryObserver(queryClient, {
-      queryKey: key,
-      enabled: false,
-    })
-    const unsubscribe = observer.subscribe()
-    unsubscribe()
-
-    await sleep(100)
-
-    const query = queryCache.find(key)!
-
-    expect(cancel).toHaveBeenCalled()
-    expect(query.state).toMatchObject({
-      data: undefined,
-      status: 'idle',
-    })
-  })
-
   test('should not continue if explicitly cancelled', async () => {
     const key = queryKey()
 

--- a/src/core/tests/queryClient.test.tsx
+++ b/src/core/tests/queryClient.test.tsx
@@ -927,7 +927,7 @@ describe('queryClient', () => {
 
     test('should cancel ongoing fetches if cancelRefetch option is set (default value)', async () => {
       const key = queryKey()
-      const cancelFn = jest.fn()
+      const abortFn = jest.fn()
       let fetchCount = 0
       const observer = new QueryObserver(queryClient, {
         queryKey: key,
@@ -936,25 +936,29 @@ describe('queryClient', () => {
       })
       observer.subscribe()
 
-      queryClient.fetchQuery(key, () => {
+      queryClient.fetchQuery(key, ({ signal }) => {
         const promise = new Promise(resolve => {
           fetchCount++
           setTimeout(() => resolve(5), 10)
+          if (signal) {
+            signal.addEventListener('abort', abortFn)
+          }
         })
-        // @ts-expect-error
-        promise.cancel = cancelFn
+
         return promise
       })
 
       await queryClient.refetchQueries()
       observer.destroy()
-      expect(cancelFn).toHaveBeenCalledTimes(1)
+      if (typeof AbortSignal === 'function') {
+        expect(abortFn).toHaveBeenCalledTimes(1)
+      }
       expect(fetchCount).toBe(2)
     })
 
     test('should not cancel ongoing fetches if cancelRefetch option is set to false', async () => {
       const key = queryKey()
-      const cancelFn = jest.fn()
+      const abortFn = jest.fn()
       let fetchCount = 0
       const observer = new QueryObserver(queryClient, {
         queryKey: key,
@@ -963,19 +967,23 @@ describe('queryClient', () => {
       })
       observer.subscribe()
 
-      queryClient.fetchQuery(key, () => {
+      queryClient.fetchQuery(key, ({ signal }) => {
         const promise = new Promise(resolve => {
           fetchCount++
           setTimeout(() => resolve(5), 10)
+          if (signal) {
+            signal.addEventListener('abort', abortFn)
+          }
         })
-        // @ts-expect-error
-        promise.cancel = cancelFn
+
         return promise
       })
 
       await queryClient.refetchQueries(undefined, { cancelRefetch: false })
       observer.destroy()
-      expect(cancelFn).toHaveBeenCalledTimes(0)
+      if (typeof AbortSignal === 'function') {
+        expect(abortFn).toHaveBeenCalledTimes(0)
+      }
       expect(fetchCount).toBe(1)
     })
   })

--- a/src/reactjs/tests/useInfiniteQuery.test.tsx
+++ b/src/reactjs/tests/useInfiniteQuery.test.tsx
@@ -1782,13 +1782,12 @@ describe('useInfiniteQuery', () => {
     const key = queryKey()
     let cancelFn: jest.Mock = jest.fn()
 
-    const queryFn = () => {
+    const queryFn = ({ signal }: { signal?: AbortSignal }) => {
       const promise = new Promise<string>((resolve, reject) => {
         cancelFn = jest.fn(() => reject('Cancelled'))
+        signal?.addEventListener('abort', cancelFn)
         sleep(10).then(() => resolve('OK'))
       })
-
-      ;(promise as any).cancel = cancelFn
 
       return promise
     }
@@ -1811,6 +1810,8 @@ describe('useInfiniteQuery', () => {
 
     await waitFor(() => rendered.getByText('off'))
 
-    expect(cancelFn).toHaveBeenCalled()
+    if (typeof AbortSignal === 'function') {
+      expect(cancelFn).toHaveBeenCalled()
+    }
   })
 })

--- a/src/reactjs/tests/useQuery.test.tsx
+++ b/src/reactjs/tests/useQuery.test.tsx
@@ -3952,13 +3952,12 @@ describe('useQuery', () => {
     const key = queryKey()
     let cancelFn: jest.Mock = jest.fn()
 
-    const queryFn = () => {
+    const queryFn = ({ signal }: { signal?: AbortSignal }) => {
       const promise = new Promise<string>((resolve, reject) => {
         cancelFn = jest.fn(() => reject('Cancelled'))
+        signal?.addEventListener('abort', cancelFn)
         sleep(10).then(() => resolve('OK'))
       })
-
-      ;(promise as any).cancel = cancelFn
 
       return promise
     }
@@ -3981,7 +3980,9 @@ describe('useQuery', () => {
 
     await waitFor(() => rendered.getByText('off'))
 
-    expect(cancelFn).toHaveBeenCalled()
+    if (typeof AbortSignal === 'function') {
+      expect(cancelFn).toHaveBeenCalled()
+    }
   })
 
   it('should cancel the query if the signal was consumed and there are no more subscriptions', async () => {


### PR DESCRIPTION
- Removes cancel method from wherever possible
- Updates query cancellation tests to use abort controller and remove tests using the older method
- Update the migration docs

Fixes #2915 