### PR TITLE
Add `onMutate` to `MutationCache`

### DIFF
--- a/docs/src/pages/reference/MutationCache.md
+++ b/docs/src/pages/reference/MutationCache.md
@@ -16,7 +16,7 @@ const mutationCache = new MutationCache({
   },
   onSuccess: data => {
     console.log(data)
-  }
+  },
 })
 ```
 
@@ -34,11 +34,16 @@ Its available methods are:
 - `onSuccess?: (data: unknown, variables: unknown, context: unknown, mutation: Mutation) => void`
   - Optional
   - This function will be called if some mutation is successful.
+- `onMutate?: (variables: unknown, mutation: Mutation) => void`
+  - Optional
+  - This function will be called before some mutation executes.
 
 ## Global callbacks
 
-The `onError` and `onSuccess` callbacks on the MutationCache can be used to handle these events on a global level. They are different to `defaultOptions` provided to the QueryClient because:
+The `onError`, `onSuccess` and `onMutate` callbacks on the MutationCache can be used to handle these events on a global level. They are different to `defaultOptions` provided to the QueryClient because:
+
 - `defaultOptions` can be overridden by each Mutation - the global callbacks will **always** be called.
+- `onMutate` does not allow returning a context value.
 
 ## `mutationCache.getAll`
 

--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -143,6 +143,13 @@ export class Mutation<
     if (!restored) {
       this.dispatch({ type: 'loading', variables: this.options.variables! })
       promise = promise
+        .then(() => {
+          // Notify cache callback
+          this.mutationCache.config.onMutate?.(
+            this.state.variables,
+            this as Mutation<unknown, unknown, unknown, unknown>
+          )
+        })
         .then(() => this.options.onMutate?.(this.state.variables!))
         .then(context => {
           if (context !== this.state.context) {

--- a/src/core/mutationCache.ts
+++ b/src/core/mutationCache.ts
@@ -20,6 +20,10 @@ interface MutationCacheConfig {
     context: unknown,
     mutation: Mutation<unknown, unknown, unknown, unknown>
   ) => void
+  onMutate?: (
+    variables: unknown,
+    mutation: Mutation<unknown, unknown, unknown, unknown>
+  ) => void
 }
 
 type MutationCacheListener = (mutation?: Mutation) => void

--- a/src/core/tests/mutationCache.test.tsx
+++ b/src/core/tests/mutationCache.test.tsx
@@ -53,6 +53,29 @@ describe('mutationCache', () => {
       )
     })
   })
+  describe('MutationCacheConfig.onMutate', () => {
+    test('should be called before a mutation executes', async () => {
+      const consoleMock = mockConsoleError()
+      const key = queryKey()
+      const onMutate = jest.fn()
+      const testCache = new MutationCache({ onMutate })
+      const testClient = new QueryClient({ mutationCache: testCache })
+
+      try {
+        await testClient.executeMutation({
+          mutationKey: key,
+          variables: 'vars',
+          mutationFn: () => Promise.resolve({ data: 5 }),
+          onMutate: () => 'context',
+        })
+      } catch {
+        consoleMock.mockRestore()
+      }
+
+      const mutation = testCache.getAll()[0]
+      expect(onMutate).toHaveBeenCalledWith('vars', mutation)
+    })
+  })
 
   describe('find', () => {
     test('should filter correctly', async () => {


### PR DESCRIPTION
following up on https://github.com/tannerlinsley/react-query/discussions/3035 this pr allows adding a `onMutate` callback to the global `MutationCache`. this enables e.g. managing toast notifications for mutations in one central place (see example below). note that it is not allowed to return a context value from the `onMutate` callback.

example:
```js
import { MutationCache, QueryClient, QueryClientProvider } from "react-query";
import { Toaster, toast } from "react-hot-toast";
import { useState } from "react";

export default function App({ Component, pageProps }) {
  const [client] = useState(() => {
    return new QueryClient({
      mutationCache: new MutationCache({
        onMutate(variables, mutation) {
          toast.loading("Submitting...", { id: mutation.mutationId });
        },
        onSuccess(data, variables, context, mutation) {
          toast.success("Success", { id: mutation.mutationId });
        },
        onError(error, variables, context, mutation) {
          toast.error("Failed", { id: mutation.mutationId });
        },
      }),
    });
  });

  return (
    <QueryClientProvider client={client}>
      <Component {...pageProps} />
      <Toaster />
    </QueryClientProvider>
  );
}
```