### PR TITLE
fix(queriesObserver): fix getOptimisticResult, order of returned observers

### DIFF
--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -65,7 +65,7 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
 
   getOptimisticResult(queries: QueryObserverOptions[]): QueryObserverResult[] {
     return this.findMatchingObservers(queries).map(match =>
-      match.observer.getCurrentResult()
+      match.observer.getOptimisticResult(match.defaultedQueryOptions)
     )
   }
 

--- a/src/core/queriesObserver.ts
+++ b/src/core/queriesObserver.ts
@@ -121,7 +121,16 @@ export class QueriesObserver extends Subscribable<QueriesObserverListener> {
       }
     )
 
-    return matchingObservers.concat(newOrReusedObservers)
+    const sortMatchesByOrderOfQueries = (
+      a: QueryObserverMatch,
+      b: QueryObserverMatch
+    ): number =>
+      defaultedQueryOptions.indexOf(a.defaultedQueryOptions) -
+      defaultedQueryOptions.indexOf(b.defaultedQueryOptions)
+
+    return matchingObservers
+      .concat(newOrReusedObservers)
+      .sort(sortMatchesByOrderOfQueries)
   }
 
   private getObserver(options: QueryObserverOptions): QueryObserver {

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -128,8 +128,8 @@ describe('useQueries', () => {
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
     ])
     expect(states[3]).toMatchObject([
-      { status: 'success', data: 2, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 2, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 5, isPreviousData: true, isFetching: true },
     ])
     expect(states[4]).toMatchObject([
       { status: 'success', data: 2, isPreviousData: true, isFetching: true },
@@ -206,8 +206,8 @@ describe('useQueries', () => {
     ])
 
     expect(states[3]).toMatchObject([
-      { status: 'success', data: 4, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 8, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 4, isPreviousData: true, isFetching: true },
+      { status: 'success', data: 8, isPreviousData: true, isFetching: true },
       {
         status: 'loading',
         data: undefined,
@@ -324,7 +324,7 @@ describe('useQueries', () => {
     ])
     expect(states[3]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 10, isPreviousData: true, isFetching: true },
     ])
     expect(states[4]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
@@ -336,7 +336,7 @@ describe('useQueries', () => {
     ])
     expect(states[6]).toMatchObject([
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
-      { status: 'success', data: 5, isPreviousData: false, isFetching: false },
+      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
     ])
     expect(states[7]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: true },

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -293,7 +293,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(10))
+    await waitFor(() => expect(states.length).toBe(9))
 
     expect(states[0]).toMatchObject([
       {
@@ -335,18 +335,14 @@ describe('useQueries', () => {
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[6]).toMatchObject([
-      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
       { status: 'success', data: 10, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[7]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: true },
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
     expect(states[8]).toMatchObject([
-      { status: 'success', data: 10, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 15, isPreviousData: false, isFetching: false },
-    ])
-    expect(states[9]).toMatchObject([
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
       { status: 'success', data: 15, isPreviousData: false, isFetching: false },
     ])
@@ -390,7 +386,7 @@ describe('useQueries', () => {
 
     renderWithClient(queryClient, <Page />)
 
-    await waitFor(() => expect(states.length).toBe(9))
+    await waitFor(() => expect(states.length).toBe(8))
 
     expect(states[0]).toMatchObject([
       {
@@ -426,18 +422,14 @@ describe('useQueries', () => {
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
     expect(states[5]).toMatchObject([
-      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
       { status: 'success', data: 5, isPreviousData: false, isFetching: true },
+      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
     expect(states[6]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: true },
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])
     expect(states[7]).toMatchObject([
-      { status: 'success', data: 5, isPreviousData: false, isFetching: true },
-      { status: 'success', data: 10, isPreviousData: false, isFetching: false },
-    ])
-    expect(states[8]).toMatchObject([
       { status: 'success', data: 5, isPreviousData: false, isFetching: false },
       { status: 'success', data: 10, isPreviousData: false, isFetching: false },
     ])


### PR DESCRIPTION
Fix for `queriesObserver.getOptimisticResult` to correctly call `getOptimisticResult` on the observers. 

This was an issue I introduced in PR #2866. There I had needed to tweak [two](https://github.com/tannerlinsley/react-query/pull/2866/files#diff-27ab6cf11862f134526488fd6c22381bf484a5ad9a6d7dc36535e1d3e2d5aa42R209) [original](https://github.com/tannerlinsley/react-query/pull/2866/files#diff-27ab6cf11862f134526488fd6c22381bf484a5ad9a6d7dc36535e1d3e2d5aa42R131) tests, which now in hindsight were off due to this issue. I now reverted those tests back to the original form.

Now testing the issue, I also noticed a small issue with the order of the observers returned by `findMatchingObservers`: with `keepPreviousData: true`, any repurposed observers would be returned last, potentially in different order than the given queries. 

The fix is just to sort the observer entries by the order of the queries before returning them. This also gets rid of an extra render at least in some tests. As this was a rather small fix, I included the commit for that fix here, but I can also put it in a separate PR if that would be cleaner.