### PR TITLE
docs: Make react-native example up-to-date

### DIFF
--- a/docs/src/pages/guides/window-focus-refetching.md
+++ b/docs/src/pages/guides/window-focus-refetching.md
@@ -68,10 +68,12 @@ import { AppState } from 'react-native'
 import { focusManager } from 'react-query'
 
 focusManager.setEventListener(handleFocus => {
-  AppState.addEventListener('change', handleFocus)
+  const subscription = AppState.addEventListener('change', state => {
+    handleFocus(state === 'active')
+  })
 
   return () => {
-   AppState.removeEventListener('change', handleFocus)
+    subscription.remove()
   }
 })
 ```


### PR DESCRIPTION
- Fixed incorrect function signature of AppState change event listener
- Update cleanup function as `removeEventListener` is [deprecated](https://reactnative.dev/docs/appstate#removeeventlistener)