### PR TITLE
docs: Update does-this-replace-client-state.md

### DIFF
--- a/docs/src/pages/guides/does-this-replace-client-state.md
+++ b/docs/src/pages/guides/does-this-replace-client-state.md
@@ -38,7 +38,7 @@ const globalState = {
 }
 ```
 
-This also means that with a few hook calls to `useQuery` and `useMutation`, we also get to remove any boilerplate code that use to manage our server state eg.
+This also means that with a few hook calls to `useQuery` and `useMutation`, we also get to remove any boilerplate code that was used to manage our server state eg.
 
 - Connectors
 - Action Creators


### PR DESCRIPTION
 * changed "any boilerplate code that use"  to boilerplate code that was used" to improve the clarity of the sentence.