### PR TITLE
Update migrating-to-react-query-4.md

### DIFF
--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -45,9 +45,9 @@ The `cancelRefetch` can be passed to all functions that imperatively fetch a que
   - `queryClient.invalidateQueries`
   - `queryClient.resetQueries`
 - `refetch` returned from `useQuery`
-- `fetchNetPage` and `fetchPreviousPage` returned from `useInfiniteQuery`
+- `fetchNextPage` and `fetchPreviousPage` returned from `useInfiniteQuery`
 
-Except for `fetchNetxPage` and `fetchPreviousPage`, this flag was defaulting to `false`, which was inconsistent and potentially troublesome: Calling `refetchQueries` or `invalidateQueries` after a mutation might not yield the latest result if a previous slow fetch was already ongoing, because this refetch would have been skipped.
+Except for `fetchNextPage` and `fetchPreviousPage`, this flag was defaulting to `false`, which was inconsistent and potentially troublesome: Calling `refetchQueries` or `invalidateQueries` after a mutation might not yield the latest result if a previous slow fetch was already ongoing, because this refetch would have been skipped.
 
 We believe that if a query is actively refetched by some code you write, it should, per default, re-start the fetch.
 

--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -42,8 +42,8 @@ In v4, `notifyOnChangeProps` defaults to the `"tracked"` behavior of v3 instead 
 The `cancelRefetch` can be passed to all functions that imperatively fetch a query, namely:
 
 - `queryClient.refetchQueries`
-  - `queryClient.invalidateQueries`
-  - `queryClient.resetQueries`
+- `queryClient.invalidateQueries`
+- `queryClient.resetQueries`
 - `refetch` returned from `useQuery`
 - `fetchNextPage` and `fetchPreviousPage` returned from `useInfiniteQuery`
 

--- a/docs/src/pages/guides/migrating-to-react-query-4.md
+++ b/docs/src/pages/guides/migrating-to-react-query-4.md
@@ -39,7 +39,7 @@ In v4, `notifyOnChangeProps` defaults to the `"tracked"` behavior of v3 instead 
 
 ### Consistent behavior for `cancelRefetch`
 
-The `cancelRefetch` can be passed to all functions that imperatively fetch a query, namely:
+The `cancelRefetch` option can be passed to all functions that imperatively fetch a query, namely:
 
 - `queryClient.refetchQueries`
 - `queryClient.invalidateQueries`


### PR DESCRIPTION
Fix a typo in the migration guide