### PR TITLE
fix(query): set error to null when going to loading state

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -584,7 +584,10 @@ export class Query<
           fetchMeta: action.meta ?? null,
           isFetching: true,
           isPaused: false,
-          status: !state.dataUpdatedAt ? 'loading' : state.status,
+          ...(!state.dataUpdatedAt && {
+            error: null,
+            status: 'loading',
+          }),
         }
       case 'success':
         return {


### PR DESCRIPTION
to be aligned with the types, as `loading` cannot have an `error` set.

closes #3090 