### PR TITLE
fix(devtools): code  color is not inherited from panel color (#3114)

### DIFF
--- a/src/devtools/styledComponents.ts
+++ b/src/devtools/styledComponents.ts
@@ -65,6 +65,7 @@ export const QueryKey = styled('span', {
 
 export const Code = styled('code', {
   fontSize: '.9em',
+  color: 'inherit',
 })
 
 export const Input = styled('input', (_props, theme) => ({


### PR DESCRIPTION
fixes #3114

add explicit color inherit on `Code` styled component to avoid default color set via external stylesheets.