### PR TITLE
fix(types): use core types in useMutation instead of redefining them

### DIFF
--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,15 +1,12 @@
-import { RetryValue, RetryDelayValue } from '../core/retryer'
 import {
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
   MutationObserverResult,
-  MutationKey,
   QueryObserverOptions,
   QueryObserverResult,
   QueryKey,
-  MutationFunction,
-  MutateOptions,
-  MutationMeta,
+  MutationObserverOptions,
+  MutateFunction,
 } from '../core/types'
 
 export interface UseBaseQueryOptions<
@@ -73,33 +70,10 @@ export interface UseMutationOptions<
   TError = unknown,
   TVariables = void,
   TContext = unknown
-> {
-  mutationFn?: MutationFunction<TData, TVariables>
-  mutationKey?: MutationKey
-  onMutate?: (
-    variables: TVariables
-  ) => Promise<TContext | undefined> | TContext | undefined
-  onSuccess?: (
-    data: TData,
-    variables: TVariables,
-    context: TContext | undefined
-  ) => Promise<unknown> | void
-  onError?: (
-    error: TError,
-    variables: TVariables,
-    context: TContext | undefined
-  ) => Promise<unknown> | void
-  onSettled?: (
-    data: TData | undefined,
-    error: TError | null,
-    variables: TVariables,
-    context: TContext | undefined
-  ) => Promise<unknown> | void
-  retry?: RetryValue<TError>
-  retryDelay?: RetryDelayValue<TError>
-  useErrorBoundary?: boolean | ((error: TError) => boolean)
-  meta?: MutationMeta
-}
+> extends Omit<
+    MutationObserverOptions<TData, TError, TVariables, TContext>,
+    '_defaulted' | 'variables'
+  > {}
 
 export type UseMutateFunction<
   TData = unknown,
@@ -107,8 +81,7 @@ export type UseMutateFunction<
   TVariables = void,
   TContext = unknown
 > = (
-  variables: TVariables,
-  options?: MutateOptions<TData, TError, TVariables, TContext>
+  ...args: Parameters<MutateFunction<TData, TError, TVariables, TContext>>
 ) => void
 
 export type UseMutateAsyncFunction<
@@ -116,10 +89,7 @@ export type UseMutateAsyncFunction<
   TError = unknown,
   TVariables = void,
   TContext = unknown
-> = (
-  variables: TVariables,
-  options?: MutateOptions<TData, TError, TVariables, TContext>
-) => Promise<TData>
+> = MutateFunction<TData, TError, TVariables, TContext>
 
 export type UseBaseMutationResult<
   TData = unknown,


### PR DESCRIPTION
Using core types, instead of custom ones for `useMutation`.

One question though. Why `variables` and `_defaulted` exist for `MutationObserver` but not for `useMutation`?

@TkDodo 