### PR TITLE
refactor(fetchTodoById): use tripple equal instead of double equal

### DIFF
--- a/examples/playground/src/index.js
+++ b/examples/playground/src/index.js
@@ -397,7 +397,7 @@ function fetchTodoById({ id }) {
           new Error(JSON.stringify({ fetchTodoById: { id } }, null, 2))
         );
       }
-      resolve(list.find((d) => d.id == id));
+      resolve(list.find((d) => d.id === id));
     }, queryTimeMin + Math.random() * (queryTimeMax - queryTimeMin));
   });
 }


### PR DESCRIPTION
Just something I found when playing around in the development enviroment of this project. No biggie - but still :).