### PR TITLE
Break down `persistQueryClient`

### DIFF
--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -89,7 +89,7 @@ persistQueryClientRestore({
   persister,
   maxAge = 1000 * 60 * 60 * 24, // 24 hours
   buster = '',
-  hydrateOptions,
+  hydrateOptions = undefined,
 })
 ```
 
@@ -102,7 +102,7 @@ persistQueryClientSave({
   queryClient,
   persister,
   buster = '',
-  dehydrateOptions,
+  dehydrateOptions = undefined,
 })
 ```
 
@@ -118,7 +118,7 @@ persistQueryClientSubscribe({
   queryClient,
   persister,
   buster = '',
-  dehydrateOptions,
+  dehydrateOptions = undefined,
 })
 ```
 
@@ -132,8 +132,8 @@ persistQueryClient({
   persister,
   maxAge = 1000 * 60 * 60 * 24, // 24 hours
   buster = '',
-  hydrateOptions,
-  dehydrateOptions,
+  hydrateOptions = undefined,
+  dehydrateOptions = undefined,
 })
 ```
 

--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -124,7 +124,7 @@ persistQueryClientSubscribe({
 
 ### `persistQueryClient`
 
-This will automatically restore any persisted cache and permanently subscribe to the query cache to persist any changes from the query cache to the persister.
+This will automatically restore any persisted cache and subscribes to the query cache to persist any changes from the query cache to the persister. It returns an `unsubscribe` function which you can use to discontinue the monitor; ending the updates to the persisted cache.
 
 ```ts
 persistQueryClient({

--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -70,7 +70,7 @@ persistQueryClient({ queryClient, persister, buster: buildHash })
 
 When you reload/bootstrap your app:
 
-- Attempts to [`hydrate`](../reference/hydration#hydrate) a previously persisted dehydrated query/mutation cache from the persister back into the query cache.
+- Attempts to [`hydrate`](../reference/hydration#hydrate) a previously persisted dehydrated query/mutation cache from the persister back into the query cache of the passed query client.
 - If a cache is found that is older than the `maxAge` (which by default is 24 hours), it will be discarded. This can be customized as you see fit.
 
 ### Removal
@@ -81,7 +81,7 @@ When you reload/bootstrap your app:
 
 ### `persistQueryClientRestore`
 
-This will attempt to restore a persister's stored cached to the active query cache.
+This will attempt to restore a persister's stored cached to the query cache of the passed queryClient.
 
 ```ts
 persistQueryClientRestore({

--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -79,12 +79,62 @@ When you reload/bootstrap your app:
 
 ## API
 
-### `persistQueryClient`
+### `persistQueryClientRestore`
 
-Pass this function a `QueryClient` instance and a persister that will persist your cache. Both are **required**
+This will attempt to restore a persister's stored cached to the active query cache.
 
 ```ts
-persistQueryClient({ queryClient, persister })
+persistQueryClientRestore({
+  queryClient,
+  persister,
+  maxAge = 1000 * 60 * 60 * 24, // 24 hours
+  buster = '',
+  hydrateOptions,
+})
+```
+
+### `persistQueryClientSave`
+
+This will attempt to save the current query cache with the persister. You can use this to explicitly persist the cache at the moments you choose.
+
+```ts
+persistQueryClientSave({
+  queryClient,
+  persister,
+  buster = '',
+  dehydrateOptions,
+})
+```
+
+### `persistQueryClientSubscribe`
+
+This will subscribe to query cache updates which will run `persistQueryClientSave`. For example: you might initiate the `subscribe` when a user logs-in and checks "Remember me".
+
+- It returns an `unsubscribe` function which you can use to discontinue the monitor; ending the updates to the persisted cache.
+- If you want to erase the persisted cache after the `unsubscribe`, you can send a new `buster` to `persistQueryClientRestore` which will trigger the persister's `removeClient` function and discard the persisted cache.
+
+```ts
+persistQueryClientSubscribe({
+  queryClient,
+  persister,
+  buster = '',
+  dehydrateOptions,
+})
+```
+
+### `persistQueryClient`
+
+This will automatically restore any persisted cache and permanently subscribe to the query cache to persist any changes from the query cache to the persister.
+
+```ts
+persistQueryClient({
+  queryClient,
+  persister,
+  maxAge = 1000 * 60 * 60 * 24, // 24 hours
+  buster = '',
+  hydrateOptions,
+  dehydrateOptions,
+})
 ```
 
 ### `Options`
@@ -110,15 +160,6 @@ interface PersistQueryClientOptions {
   hydrateOptions?: HydrateOptions
   /** The options passed to the dehydrate function */
   dehydrateOptions?: DehydrateOptions
-}
-```
-
-The default options are:
-
-```ts
-{
-  maxAge = 1000 * 60 * 60 * 24, // 24 hours
-  buster = '',
 }
 ```
 

--- a/docs/src/pages/reference/hydration.md
+++ b/docs/src/pages/reference/hydration.md
@@ -48,7 +48,7 @@ const dehydratedState = dehydrate(queryClient, {
 
 ### limitations
 
-The hydration API requires values to be JSON serializable. If you need to dehydrate values that are not automatically serializable to JSON (like `Error` or `undefined`), you have to serialize them for yourself. Since only successful queries are included per default, to also include `Errors`, you have to provide `shouldDehydrateQuery`, e.g.:
+Some storage systems (such as browser [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API)) require values to be JSON serializable. If you need to dehydrate values that are not automatically serializable to JSON (like `Error` or `undefined`), you have to serialize them for yourself. Since only successful queries are included per default, to also include `Errors`, you have to provide `shouldDehydrateQuery`, e.g.:
 
 ```js
 // server
@@ -56,13 +56,13 @@ const state = dehydrate(client, { shouldDehydrateQuery: () => true }) // to also
 const serializedState = mySerialize(state) // transform Error instances to objects
 
 // client
-const state = myDeserialize(serializedState)  // transform objects back to Error instances
+const state = myDeserialize(serializedState) // transform objects back to Error instances
 hydrate(client, state)
 ```
 
 ## `hydrate`
 
-`hydrate` adds a previously dehydrated state into a `cache`. If the queries included in dehydration already exist in the queryCache, `hydrate` does not overwrite them.
+`hydrate` adds a previously dehydrated state into a `cache`.
 
 ```js
 import { hydrate } from 'react-query'
@@ -84,6 +84,10 @@ hydrate(queryClient, dehydratedState, options)
     - Optional
     - `mutations: MutationOptions` The default mutation options to use for the hydrated mutations.
     - `queries: QueryOptions` The default query options to use for the hydrated queries.
+
+### Limitations
+
+If the queries included in dehydration already exist in the queryCache, `hydrate` does not overwrite them and they will be **silently** discarded.
 
 ## `useHydrate`
 

--- a/src/persistQueryClient/index.ts
+++ b/src/persistQueryClient/index.ts
@@ -137,6 +137,6 @@ export async function persistQueryClient(props: PersistQueryClientOptions) {
     persistQueryClientRestore(props)
 
     // Subscribe to changes in the query cache to trigger the save
-    persistQueryClientSubscribe(props)
+    return persistQueryClientSubscribe(props)
   }
 }

--- a/src/persistQueryClient/index.ts
+++ b/src/persistQueryClient/index.ts
@@ -21,46 +21,52 @@ export interface PersistedClient {
   clientState: DehydratedState
 }
 
-export interface PersistQueryClientOptions {
+export interface PersistQueryClienRootOptions {
   /** The QueryClient to persist */
   queryClient: QueryClient
   /** The Persister interface for storing and restoring the cache
    * to/from a persisted location */
   persister: Persister
-  /** The max-allowed age of the cache.
-   * If a persisted cache is found that is older than this
-   * time, it will be discarded */
-  maxAge?: number
   /** A unique string that can be used to forcefully
    * invalidate existing caches if they do not share the same buster string */
   buster?: string
+}
+
+export interface PersistedQueryClientRestoreOptions
+  extends PersistQueryClienRootOptions {
+  /** The max-allowed age of the cache in milliseconds.
+   * If a persisted cache is found that is older than this
+   * time, it will be discarded */
+  maxAge?: number
   /** The options passed to the hydrate function */
   hydrateOptions?: HydrateOptions
+}
+
+export interface PersistedQueryClientSaveOptions
+  extends PersistQueryClienRootOptions {
   /** The options passed to the dehydrate function */
   dehydrateOptions?: DehydrateOptions
 }
 
-export async function persistQueryClient({
+export interface PersistQueryClientOptions
+  extends PersistedQueryClientRestoreOptions,
+    PersistedQueryClientSaveOptions,
+    PersistQueryClienRootOptions {}
+
+/**
+ * Restores persisted data to the QueryCache
+ *  - data obtained from persister.restoreClient
+ *  - data is hydrated using hydrateOptions
+ * If data is expired, busted, empty, or throws, it runs persister.removeClient
+ */
+export async function persistQueryClientRestore({
   queryClient,
   persister,
   maxAge = 1000 * 60 * 60 * 24,
   buster = '',
   hydrateOptions,
-  dehydrateOptions,
-}: PersistQueryClientOptions) {
+}: PersistedQueryClientRestoreOptions) {
   if (typeof window !== 'undefined') {
-    // Subscribe to changes
-    const saveClient = () => {
-      const persistClient: PersistedClient = {
-        buster,
-        timestamp: Date.now(),
-        clientState: dehydrate(queryClient, dehydrateOptions),
-      }
-
-      persister.persistClient(persistClient)
-    }
-
-    // Attempt restore
     try {
       const persistedClient = await persister.restoreClient()
 
@@ -84,8 +90,53 @@ export async function persistQueryClient({
       )
       persister.removeClient()
     }
+  }
+}
+
+/**
+ * Persists data from the QueryCache
+ *  - data dehydrated using dehydrateOptions
+ *  - data is persisted using persister.persistClient
+ */
+export async function persistQueryClientSave({
+  queryClient,
+  persister,
+  buster = '',
+  dehydrateOptions,
+}: PersistedQueryClientSaveOptions) {
+  if (typeof window !== 'undefined') {
+    const persistClient: PersistedClient = {
+      buster,
+      timestamp: Date.now(),
+      clientState: dehydrate(queryClient, dehydrateOptions),
+    }
+
+    await persister.persistClient(persistClient)
+  }
+}
+
+/**
+ * Subscribe to QueryCache updates (for persisting)
+ * @returns an unsubscribe function (to discontinue monitoring)
+ */
+export function persistQueryClientSubscribe(
+  props: PersistedQueryClientSaveOptions
+) {
+  return props.queryClient.getQueryCache().subscribe(() => {
+    persistQueryClientSave(props)
+  })
+}
+
+/**
+ * Restores persisted data to QueryCache and persists further changes.
+ * (Retained for backwards compatibility)
+ */
+export async function persistQueryClient(props: PersistQueryClientOptions) {
+  if (typeof window !== 'undefined') {
+    // Attempt restore
+    persistQueryClientRestore(props)
 
     // Subscribe to changes in the query cache to trigger the save
-    queryClient.getQueryCache().subscribe(saveClient)
+    persistQueryClientSubscribe(props)
   }
 }

--- a/src/persistQueryClient/index.ts
+++ b/src/persistQueryClient/index.ts
@@ -134,7 +134,7 @@ export function persistQueryClientSubscribe(
 export async function persistQueryClient(props: PersistQueryClientOptions) {
   if (typeof window !== 'undefined') {
     // Attempt restore
-    persistQueryClientRestore(props)
+    await persistQueryClientRestore(props)
 
     // Subscribe to changes in the query cache to trigger the save
     return persistQueryClientSubscribe(props)


### PR DESCRIPTION
Per discussion #3129 

1. Break down `persistQueryClient` into its various tasks
2. Return an unsubscribe callback when subscribing a persister
3. Update docs

holding on the other updates to keep it more straightforward for now.