### PR TITLE
Pr/make useIsMounted reused

### DIFF
--- a/src/devtools/devtools.tsx
+++ b/src/devtools/devtools.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Query, useQueryClient } from 'react-query'
 import { matchSorter } from 'match-sorter'
 import useLocalStorage from './useLocalStorage'
-import { useIsMounted, useSafeState } from './utils'
+import { useSafeState } from './utils'
 
 import {
   Panel,
@@ -20,6 +20,7 @@ import { getQueryStatusLabel, getQueryStatusColor } from './utils'
 import Explorer from './Explorer'
 import Logo from './Logo'
 import { noop } from '../core/utils'
+import { useIsMounted } from '../react/utils'
 
 interface DevtoolsOptions {
   /**

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -3,8 +3,7 @@ import { Query } from '../core'
 
 import { Theme, useTheme } from './theme'
 import useMediaQuery from './useMediaQuery'
-
-export const isServer = typeof window === 'undefined'
+import { useIsMounted } from '../react/utils'
 
 type StyledComponent<T> = T extends 'button'
   ? React.DetailedHTMLProps<
@@ -84,20 +83,6 @@ export function styled<T extends keyof HTMLElementTagNameMap>(
       })
     }
   )
-}
-
-export function useIsMounted() {
-  const mountedRef = React.useRef(false)
-  const isMounted = React.useCallback(() => mountedRef.current, [])
-
-  React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-
-  return isMounted
 }
 
 /**

--- a/src/react/tests/utils.test.tsx
+++ b/src/react/tests/utils.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { useIsMounted } from '../utils'
+
+function setup() {
+  let isMounted = () => false
+  function TestComponent() {
+    isMounted = useIsMounted()
+    return null
+  }
+  const { unmount } = render(<TestComponent />)
+  return { isMounted, unmount }
+}
+
+describe('react/utils', () => {
+  describe('useIsMounted', () => {
+    it('isMounted should return true when component mounted', () => {
+      const { isMounted } = setup()
+      expect(isMounted()).toBe(true)
+    })
+
+    it('isMounted should return false when component is not mounted', () => {
+      const { isMounted, unmount } = setup()
+      unmount()
+      expect(isMounted()).toBe(false)
+    })
+  })
+})

--- a/src/react/useIsFetching.ts
+++ b/src/react/useIsFetching.ts
@@ -4,6 +4,7 @@ import { notifyManager } from '../core/notifyManager'
 import { QueryKey } from '../core/types'
 import { parseFilterArgs, QueryFilters } from '../core/utils'
 import { useQueryClient } from './QueryClientProvider'
+import { useIsMounted } from './utils'
 
 export function useIsFetching(filters?: QueryFilters): number
 export function useIsFetching(
@@ -14,7 +15,7 @@ export function useIsFetching(
   arg1?: QueryKey | QueryFilters,
   arg2?: QueryFilters
 ): number {
-  const mountedRef = React.useRef(false)
+  const isMounted = useIsMounted()
 
   const queryClient = useQueryClient()
 
@@ -29,11 +30,9 @@ export function useIsFetching(
   isFetchingRef.current = isFetching
 
   React.useEffect(() => {
-    mountedRef.current = true
-
     const unsubscribe = queryClient.getQueryCache().subscribe(
       notifyManager.batchCalls(() => {
-        if (mountedRef.current) {
+        if (isMounted()) {
           const newIsFetching = queryClient.isFetching(filtersRef.current)
           if (isFetchingRef.current !== newIsFetching) {
             setIsFetching(newIsFetching)
@@ -43,10 +42,9 @@ export function useIsFetching(
     )
 
     return () => {
-      mountedRef.current = false
       unsubscribe()
     }
-  }, [queryClient])
+  }, [queryClient, isMounted])
 
   return isFetching
 }

--- a/src/react/useMutation.ts
+++ b/src/react/useMutation.ts
@@ -10,7 +10,7 @@ import {
   UseMutationResult,
 } from './types'
 import { MutationFunction, MutationKey } from '../core/types'
-import { shouldThrowError } from './utils'
+import { shouldThrowError, useIsMounted } from './utils'
 
 // HOOK
 
@@ -74,7 +74,7 @@ export function useMutation<
     | UseMutationOptions<TData, TError, TVariables, TContext>,
   arg3?: UseMutationOptions<TData, TError, TVariables, TContext>
 ): UseMutationResult<TData, TError, TVariables, TContext> {
-  const mountedRef = React.useRef(false)
+  const isMounted = useIsMounted()
   const [, forceUpdate] = React.useState(0)
 
   const options = parseMutationArgs(arg1, arg2, arg3)
@@ -91,20 +91,17 @@ export function useMutation<
   const currentResult = obsRef.current.getCurrentResult()
 
   React.useEffect(() => {
-    mountedRef.current = true
-
     const unsubscribe = obsRef.current!.subscribe(
       notifyManager.batchCalls(() => {
-        if (mountedRef.current) {
+        if (isMounted()) {
           forceUpdate(x => x + 1)
         }
       })
     )
     return () => {
-      mountedRef.current = false
       unsubscribe()
     }
-  }, [])
+  }, [isMounted])
 
   const mutate = React.useCallback<
     UseMutateFunction<TData, TError, TVariables, TContext>

--- a/src/react/utils.ts
+++ b/src/react/utils.ts
@@ -1,3 +1,7 @@
+import React from 'react'
+
+import { isServer } from '../core/utils'
+
 export function shouldThrowError<TError>(
   suspense: boolean | undefined,
   _useErrorBoundary: boolean | ((err: TError) => boolean) | undefined,
@@ -13,4 +17,18 @@ export function shouldThrowError<TError>(
 
   // If suspense is enabled default to throwing errors
   return !!suspense
+}
+
+export function useIsMounted() {
+  const mountedRef = React.useRef(false)
+  const isMounted = React.useCallback(() => mountedRef.current, [])
+
+  React[isServer ? 'useEffect' : 'useLayoutEffect'](() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return isMounted
 }


### PR DESCRIPTION
I noticed that the "useIsMounted" hook is basically used on quite some places in the code implicitly (mountedRef defined in several of hooks) and saw the opportunity to refactor out useIsMounted from src/devtools -> src/react in order to be in a more general util place and therefore it would make sense to reuse the hook everywhere in the project.

I think it makes the code more readable by using this hook rather than introducing a new useRef in every component in order to know if the component is mounted or not:
```
// OLD
...
const mountedRef = React.useRef(false)
...

useEffect(() => {
  ...
  mountedRef.current = true
  ...
  return () => {
    mountedRef.current = false
  }
}, [])
```

```
// "NEW"
...
const isMounted = useIsMounted() // use as isMounted()
...
```


**Some thinking out loud stuff:**
1. The actual hook
I have not introduced the hook myself as can be seen in the code diffing tool, but I think I moved it to a better place.
Though there are some naming conflicts with the "utils.tsx" file under the same directory. Maybe one should rename "utils.tsx" to "testUtils.tsx"? Maybe make an own file for this hook, e.g "useIsMounted.ts".
I still need to suffix the testing file with "tsx" in order to use jsx in there it seems, but does it make sense to have the following combination of files if so: useIsMounted.ts / useIsMounted.test.tsx (or maybe just useIsMounted.tsx / useIsMounted.test.tsx even though there is no jsx in the hook, but for the sake of consistent suffixes of the files)? 

2. About the tests
I haven't done much opensource before and am a bit new with the "@testing-library/react" testing library, but I think it makes sense to have some basic testing for this hook in the longer run. I peaked at the "@testing-library/react-hooks" library a bit but I dont think I need it for this case, and also did not want to add another depedency for the project.

I have a bunch more questions, but I thought maybe it could help me to throw this pr up and get some feedback on it.

Cheers!



