### PR TITLE
docs(examples): add react native expo snack example

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -306,6 +306,11 @@
           "title": "Next.js",
           "path": "/examples/nextjs",
           "editUrl": "/examples/nextjs.mdx"
+        },
+        {
+          "title": "React Native",
+          "path": "/examples/react-native",
+          "editUrl": "/examples/react-native.mdx"
         }
       ]
     },

--- a/docs/src/pages/examples/react-native.mdx
+++ b/docs/src/pages/examples/react-native.mdx
@@ -1,0 +1,22 @@
+---
+id: react-native
+title: React Native
+toc: false
+---
+
+- [Open the Snack](https://snack.expo.dev/@arnaudbzn/react-query-basic-example)
+
+<iframe
+  src="https://snack.expo.dev/@arnaudbzn/react-query-basic-example"
+  title="tannerlinsley/react-query: react native"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+  style={{
+    width: '100%',
+    height: '80vh',
+    border: '0',
+    borderRadius: 8,
+    overflow: 'hidden',
+    position: 'static',
+    zIndex: 0,
+  }}
+></iframe>


### PR DESCRIPTION
New React Native example (Expo snack). 
Basic React Native App with List / Details screens with some useful hooks.