### PR TITLE
docs(useMutation): clarify retry default value

### DIFF
--- a/docs/src/pages/reference/useMutation.md
+++ b/docs/src/pages/reference/useMutation.md
@@ -22,6 +22,8 @@ const {
   onMutate,
   onSettled,
   onSuccess,
+  retry,
+  retryDelay,
   useErrorBoundary,
   meta,
 })
@@ -60,7 +62,8 @@ mutate(variables, {
   - This function will fire when the mutation is either successfully fetched or encounters an error and be passed either the data or error
   - If a promise is returned, it will be awaited and resolved before proceeding
 - `retry: boolean | number | (failureCount: number, error: TError) => boolean`
-  - If `false`, failed mutations will not retry by default.
+  - Defaults to `0`.
+  - If `false`, failed mutations will not retry.
   - If `true`, failed mutations will retry infinitely.
   - If set to an `number`, e.g. `3`, failed mutations will retry until the failed mutations count meets that number.
 - `retryDelay: number | (retryAttempt: number, error: TError) => number`


### PR DESCRIPTION
This makes the default value more apparent and adds `retry` and `retryDelay` to the example code.

I had to read through [the code](https://github.com/tannerlinsley/react-query/blob/aec640a5952f3787fc0efd0f39d7b51431110d43/src/core/mutation.ts#L248) to figure out what the default is.

Thanks for the AWESOME library!