### PR TITLE
fix(examples/load-more-infinite-scroll): fix wrong condtion

### DIFF
--- a/examples/load-more-infinite-scroll/pages/index.js
+++ b/examples/load-more-infinite-scroll/pages/index.js
@@ -65,9 +65,9 @@ function Example() {
               onClick={() => fetchPreviousPage()}
               disabled={!hasPreviousPage || isFetchingPreviousPage}
             >
-              {isFetchingNextPage
+              {isFetchingPreviousPage
                 ? 'Loading more...'
-                : hasNextPage
+                : hasPreviousPage
                 ? 'Load Older'
                 : 'Nothing more to load'}
             </button>


### PR DESCRIPTION
Fixes [issue](https://github.com/tannerlinsley/react-query/issues/3171).

Scope: **[Load More / Infinite Scroll example]**
The top button contained wrong text due to wrong variables used in the corresponding condition that determines its text. 
This PR fixes the use of the wrong variables.
