### PR TITLE
fix(queryObserver): fix data stability

### DIFF
--- a/src/core/queryObserver.ts
+++ b/src/core/queryObserver.ts
@@ -507,12 +507,12 @@ export class QueryObserver<
       } else {
         try {
           data = options.select(state.data)
+          if (options.structuralSharing !== false) {
+            data = replaceEqualDeep(prevResult?.data, data)
+          }
           this.previousSelect = {
             fn: options.select,
             result: data,
-          }
-          if (options.structuralSharing !== false) {
-            data = replaceEqualDeep(prevResult?.data, data)
           }
           this.previousSelectError = null
         } catch (selectError) {


### PR DESCRIPTION
by making sure to memoize the structurally shared version of data rather than the raw one

closes #3181 