### PR TITLE
fix: export QueryClientConfig interface

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -10,6 +10,7 @@ import {
   MutationFilters,
 } from './utils'
 import type {
+  QueryClientConfig,
   DefaultOptions,
   FetchInfiniteQueryOptions,
   FetchQueryOptions,
@@ -39,12 +40,6 @@ import { infiniteQueryBehavior } from './infiniteQueryBehavior'
 import { CancelOptions } from './types'
 
 // TYPES
-
-interface QueryClientConfig {
-  queryCache?: QueryCache
-  mutationCache?: MutationCache
-  defaultOptions?: DefaultOptions
-}
 
 interface QueryDefaults {
   queryKey: QueryKey

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,6 +2,8 @@ import type { MutationState } from './mutation'
 import type { QueryBehavior, Query } from './query'
 import type { RetryValue, RetryDelayValue } from './retryer'
 import type { QueryFilters } from './utils'
+import type { QueryCache } from './queryCache'
+import type { MutationCache } from './mutationCache'
 
 export type QueryKey = string | readonly unknown[]
 export type EnsuredQueryKey<T extends QueryKey> = T extends string
@@ -668,6 +670,12 @@ export type MutationObserverResult<
   | MutationObserverLoadingResult<TData, TError, TVariables, TContext>
   | MutationObserverErrorResult<TData, TError, TVariables, TContext>
   | MutationObserverSuccessResult<TData, TError, TVariables, TContext>
+
+export interface QueryClientConfig {
+  queryCache?: QueryCache
+  mutationCache?: MutationCache
+  defaultOptions?: DefaultOptions
+}
 
 export interface DefaultOptions<TError = unknown> {
   queries?: QueryObserverOptions<unknown, TError>


### PR DESCRIPTION
Export QueryClientConfig interface, so it can be easily reused in wrapper libraries