### PR TITLE
docs(ssr): Hydration caveat for Next.js rewrites

### DIFF
--- a/docs/src/pages/guides/ssr.md
+++ b/docs/src/pages/guides/ssr.md
@@ -107,6 +107,12 @@ function Posts() {
 
 As demonstrated, it's fine to prefetch some queries and let others fetch on the queryClient. This means you can control what content server renders or not by adding or removing `prefetchQuery` for a specific query.
 
+### Caveat for Next.js rewrites
+
+There's a catch if you're using [Next.js' rewrites feature](https://nextjs.org/docs/api-reference/next.config.js/rewrites) together with [Automatic Static Optimization](https://nextjs.org/docs/advanced-features/automatic-static-optimization) or `getStaticProps`: It will cause a second hydration by React Query. That's because [Next.js needs to ensure that they parse the rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites#rewrite-parameters) on the client and collect any params after hydration so that they can be provided in `router.query`.
+
+The result is missing referential equality for all the hydration data, which for example triggers whereever your data is used as props of components or in the dependency array of `useEffect`s/`useMemo`s.
+
 ## Using Other Frameworks or Custom SSR Frameworks
 
 This guide is at-best, a high level overview of how SSR with React Query should work. Your mileage may vary since there are many different possible setups for SSR.


### PR DESCRIPTION
This adds a small section for a caveat about hydration when using some specific feature/configuration of Next.js.

See initial RQ discussion: https://github.com/tannerlinsley/react-query/discussions/3192

See Next.js issue: https://github.com/vercel/next.js/issues/33028#issuecomment-1012126770

---

I'm not sure if we should additionally reference the Next.js issue for this topic in the RQ docs, but my hopes are not high that the issue will be fixed "this time", as it is not really a bug per se, so I didn't here.