### PR TITLE
fix(core): make sure batching finishes if exception is thrown

### DIFF
--- a/src/core/notifyManager.ts
+++ b/src/core/notifyManager.ts
@@ -30,11 +30,15 @@ export class NotifyManager {
   }
 
   batch<T>(callback: () => T): T {
+    let result
     this.transactions++
-    const result = callback()
-    this.transactions--
-    if (!this.transactions) {
-      this.flush()
+    try {
+      result = callback()
+    } finally {
+      this.transactions--
+      if (!this.transactions) {
+        this.flush()
+      }
     }
     return result
   }

--- a/src/core/tests/notifyManager.test.tsx
+++ b/src/core/tests/notifyManager.test.tsx
@@ -29,4 +29,19 @@ describe('notifyManager', () => {
     expect(callbackBatchLevel2Spy).toHaveBeenCalledTimes(1)
     expect(callbackScheduleSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('should flush if error is thrown', () => {
+    const notifyManagerTest = new NotifyManager()
+    const flushSpy = jest.fn()
+
+    notifyManagerTest.flush = flushSpy
+
+    try {
+      notifyManagerTest.batch(() => {
+        throw new Error('Foo')
+      })
+    } catch {}
+
+    expect(flushSpy).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
incrementing and decrementing transactions need to happen in an atomic operation, no matter what happens in between; if we increment, but never decrement, we will get to a state where transactions can never become zero - we're basically "leaking" an open transaction. This leads to no observers being informed ever again because we think we still have an open transaction

this can be fixed by using try/finally to always decrement the transactions

closes #3215 