### PR TITLE
fix(useIsMutating): use MutationKey instead of QueryKey

### DIFF
--- a/docs/src/pages/reference/useIsMutating.md
+++ b/docs/src/pages/reference/useIsMutating.md
@@ -15,6 +15,7 @@ const isMutatingPosts = useIsMutating(['posts'])
 
 **Options**
 
+- `mutationKey?: string | unknown[]`
 - `filters?: MutationFilters`: [Mutation Filters](../guides/filters#mutation-filters)
 
 **Returns**

--- a/src/react/useIsMutating.ts
+++ b/src/react/useIsMutating.ts
@@ -1,18 +1,18 @@
 import React from 'react'
 
 import { notifyManager } from '../core/notifyManager'
-import { QueryKey } from '../core/types'
+import { MutationKey } from '../core/types'
 import { MutationFilters, parseMutationFilterArgs } from '../core/utils'
 import { useQueryClient } from './QueryClientProvider'
 
 export function useIsMutating(filters?: MutationFilters): number
 export function useIsMutating(
-  queryKey?: QueryKey,
-  filters?: MutationFilters
+  mutationKey?: MutationKey,
+  filters?: Omit<MutationFilters, 'mutationKey'>
 ): number
 export function useIsMutating(
-  arg1?: QueryKey | MutationFilters,
-  arg2?: MutationFilters
+  arg1?: MutationKey | MutationFilters,
+  arg2?: Omit<MutationFilters, 'mutationKey'>
 ): number {
   const mountedRef = React.useRef(false)
   const filters = parseMutationFilterArgs(arg1, arg2)


### PR DESCRIPTION
Fix TypeScript annotations and update the useIsMutating doc:
use MutationKey instead of QueryKey