### PR TITLE
docs(setQueriesData): Make setQueriesData more searchable

### DIFF
--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -203,7 +203,7 @@ This distinction is more a "convenience" for ts devs that know which structure w
 
 ## `queryClient.setQueryData`
 
-`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook in the default `cacheTime` of 5 minutes, the query will be garbage collected**.
+`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook in the default `cacheTime` of 5 minutes, the query will be garbage collected**. To do partial mathing of query keys, you need to use [`queryClient.setQueriesData`](#queryclientsetqueriesdata) instead. 
 
 After successful changing query's cached data via `setQueryData`, it will also trigger `onSuccess` callback from that query.
 
@@ -250,7 +250,7 @@ console.log(state.dataUpdatedAt)
 
 ## `queryClient.setQueriesData`
 
-`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each query.
+`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each query.
 
 ```js
 queryClient.setQueriesData(queryKey | filters, updater)
@@ -259,7 +259,7 @@ queryClient.setQueriesData(queryKey | filters, updater)
 **Options**
 
 - `queryKey: QueryKey`: [Query Keys](../guides/query-keys) | `filters: QueryFilters`: [Query Filters](../guides/filters#query-filters)
-  - if a queryKey is passed as first argument, queryKeys fuzzily matching this param will be updated
+  - if a queryKey is passed as first argument, queryKeys partially matching this param will be updated
   - if a filter is passed, queryKeys matching the filter will be updated
 - `updater: TData | (oldData: TData | undefined) => TData`
   - the [setQueryData](#queryclientsetquerydata) updater function or new data, will be called for each matching queryKey

--- a/docs/src/pages/reference/QueryClient.md
+++ b/docs/src/pages/reference/QueryClient.md
@@ -203,7 +203,7 @@ This distinction is more a "convenience" for ts devs that know which structure w
 
 ## `queryClient.setQueryData`
 
-`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook in the default `cacheTime` of 5 minutes, the query will be garbage collected**. To do partial mathing of query keys, you need to use [`queryClient.setQueriesData`](#queryclientsetqueriesdata) instead. 
+`setQueryData` is a synchronous function that can be used to immediately update a query's cached data. If the query does not exist, it will be created. **If the query is not utilized by a query hook in the default `cacheTime` of 5 minutes, the query will be garbage collected**. To update multiple queries at once and match query keys partially, you need to use [`queryClient.setQueriesData`](#queryclientsetqueriesdata) instead. 
 
 After successful changing query's cached data via `setQueryData`, it will also trigger `onSuccess` callback from that query.
 
@@ -250,7 +250,7 @@ console.log(state.dataUpdatedAt)
 
 ## `queryClient.setQueriesData`
 
-`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each query.
+`setQueriesData` is a synchronous function that can be used to immediately update cached data of multiple queries by using filter function or partially matching the query key. Only queries that match the passed queryKey or queryFilter will be updated - no new cache entries will be created. Under the hood, [`setQueryData`](#queryclientsetquerydata) is called for each query.
 
 ```js
 queryClient.setQueriesData(queryKey | filters, updater)


### PR DESCRIPTION
- Makes setQueriesData more searchable by adding keyword `partial` there
- Change mention of fuzzily matching to partial matching since fuzzy matching is more arbitrary algorithm
- Mention setQueriesData in setQueryData to avoid confusion of behaviours

The purpose of this change is to make setQueriesData a bit more searchable from the docs to avoid confusion like this: https://github.com/tannerlinsley/react-query/discussions/3239