### PR TITLE
Fix to infinite scroll without clicking more button

### DIFF
--- a/examples/load-more-infinite-scroll/pages/index.js
+++ b/examples/load-more-infinite-scroll/pages/index.js
@@ -48,7 +48,7 @@ function Example() {
   useIntersectionObserver({
     target: loadMoreButtonRef,
     onIntersect: fetchNextPage,
-    enabled: hasNextPage,
+    enabled: !!hasNextPage,
   })
 
   return (


### PR DESCRIPTION
On the first render, `hasNextPage` is `undefined`, but converted to `true` by the default value.

For intersection observer to trigger correctly without clicking more button, `hasNextPage` needs type casting.