### PR TITLE
docs(cancellation): add graphql request v4 example

### DIFF
--- a/docs/src/pages/guides/query-cancellation.md
+++ b/docs/src/pages/guides/query-cancellation.md
@@ -99,6 +99,18 @@ const query = useQuery('todos', ({ signal }) => {
 
 ## Using `graphql-request`
 
+An `AbortSignal` can be set in the client `request` method.
+
+```js
+const client = new GraphQLClient(endpoint)
+
+const query = useQuery('todos', ({ signal }) => {
+  client.request({ document: query, signal })
+})
+```
+
+## Using `graphql-request`  version less than v4.0.0
+
 An `AbortSignal` can be set in the `GraphQLClient` constructor.
 
 ```js


### PR DESCRIPTION
[graphql-request v4.0](https://www.npmjs.com/package/graphql-request#cancellation) now supports setting an AbortSignal per request.
A new Query cancellation example has been added.

Related PR https://github.com/prisma-labs/graphql-request/pull/303