### PR TITLE
fix(types): useQueries to also handle array-params with typed QueryKey

### DIFF
--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -928,7 +928,7 @@ describe('useQueries', () => {
       queries: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[]
     ) {
       return useQueries(
-        queries.map((query: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) => {
+        queries.map((query) => {
           const { queryFn: fn, queryKey: key, onError: err } = query;
           return {
             queryKey: key,

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -928,8 +928,11 @@ describe('useQueries', () => {
       queries: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[]
     ) {
       return useQueries(
-        queries.map((query) => {
+        queries.map(
+          // no need to type the mapped query
+          (query) => {
           const { queryFn: fn, queryKey: key, onError: err } = query;
+          expectType<QueryFunction<TQueryFnData, TQueryKey> | undefined>(fn)
           return {
             queryKey: key,
             onError: err,

--- a/src/react/tests/useQueries.test.tsx
+++ b/src/react/tests/useQueries.test.tsx
@@ -19,7 +19,10 @@ import {
   QueryObserverResult,
   QueriesObserver,
   QueryFunction,
+  UseQueryOptions,
+  QueryKey,
 } from '../..'
+import { EnsuredQueryKey, QueryFunctionContext } from '../../core'
 
 describe('useQueries', () => {
   const queryCache = new QueryCache()
@@ -900,7 +903,8 @@ describe('useQueries', () => {
     }
   })
 
-  it('handles types for QueryFunction factory with strongly typed QueryKey', () => {
+  it('handles strongly typed queryFn factories and useQueries wrappers', () => {
+    // QueryKey + queryFn factory
     type QueryKeyA = ['queryA']
     const getQueryKeyA = (): QueryKeyA => ['queryA']
     type GetQueryFunctionA = () => QueryFunction<number, QueryKeyA>
@@ -918,6 +922,25 @@ describe('useQueries', () => {
     }
     type SelectorB = (data: string) => [string, number]
     const getSelectorB = (): SelectorB => data => [data, +data]
+
+    // Wrapper with strongly typed array-parameter
+    function useWrappedQueries<TQueryFnData, TError, TData, TQueryKey extends QueryKey>(
+      queries: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[]
+    ) {
+      return useQueries(
+        queries.map((query: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) => {
+          const { queryFn: fn, queryKey: key, onError: err } = query;
+          return {
+            queryKey: key,
+            onError: err,
+            queryFn: (ctx: QueryFunctionContext<TQueryKey>) => {
+              expectType<EnsuredQueryKey<TQueryKey>>(ctx.queryKey)
+              return fn?.call({}, ctx);
+            }
+          }
+        })
+      )
+    }
 
     // @ts-expect-error (Page component is not rendered)
     // eslint-disable-next-line
@@ -953,6 +976,14 @@ describe('useQueries', () => {
       expectType<QueryObserverResult<[string, number], unknown>>(
         withSelector[1]
       )
+
+      const withWrappedQueries = useWrappedQueries(Array(10).map(() => ({
+        queryKey: getQueryKeyA(),
+        queryFn: getQueryFunctionA(),
+        select: getSelectorA(),
+      })))
+
+      expectType<QueryObserverResult<number | undefined, unknown>[]>(withWrappedQueries);
     }
   })
 

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -84,8 +84,8 @@ export type QueriesOptions<
   ? T
   : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
   // use this to infer the param types in the case of Array.map() argument
-  T extends UseQueryOptions<infer TQueryFnData, infer TError, infer TData>[]
-  ? UseQueryOptions<TQueryFnData, TError, TData>[]
+  T extends UseQueryOptions<infer TQueryFnData, infer TError, infer TData, infer TQueryKey>[]
+  ? UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>[]
   : // Fallback
     UseQueryOptions[]
 
@@ -104,7 +104,7 @@ export type QueriesResults<
   ? [...Result, GetResults<Head>]
   : T extends [infer Head, ...infer Tail]
   ? QueriesResults<[...Tail], [...Result, GetResults<Head>], [...Depth, 1]>
-  : T extends UseQueryOptions<infer TQueryFnData, infer TError, infer TData>[]
+  : T extends UseQueryOptions<infer TQueryFnData, infer TError, infer TData, any>[]
   ? // Dynamic-size (homogenous) UseQueryOptions array: map directly to array of results
     UseQueryResult<unknown extends TData ? TQueryFnData : TData, TError>[]
   : // Fallback


### PR DESCRIPTION
Relates to discussion https://github.com/tannerlinsley/react-query/discussions/3242, and very similar to PR https://github.com/tannerlinsley/react-query/pull/3214 - this update ensures we also pass down the QueryKey type when working with regular array parameters (i.e. not a variadic tuple), making it easier to create wrappers around `useQueries`.
