### PR TITLE
docs(mutations): describe difference between using callbacks in useMu…

### DIFF
--- a/docs/src/pages/guides/mutations.md
+++ b/docs/src/pages/guides/mutations.md
@@ -180,7 +180,9 @@ mutate(todo, {
 ```
 
 ### Consecutive mutations
-For consecutive mutations, you may consider passing `onSuccess`, `onError` and `onSettled` to the `mutate` function instead of `useMutation`. Then, these callbacks will fire only _once_ after last mutation is fulfilled, and only if the component is still mounted. It might be useful for performance optimisation (ie. when invalidating queries after mutation). This is due to the fact that the mutation observer is removed and resubscribed every time when the `mutate` function is called.
+There is a slight difference in handling `onSuccess`, `onError` and `onSettled` callbacks when it comes to consecutive mutations. When passed to the `mutate` function, they will be fired up only _once_ and only if the component is still mounted.  This is due to the fact that mutation observer is removed and resubscribed every time when the `mutate` function is called. On the contrary, `useMutation` handlers execute for each `mutate` call.
+
+> Be aware that most likely, `mutationFn` passed to `useMutation` is ansynchronous. In that case, the order in which mutations are fulfilled may differ from the order of `mutate` function calls.
 
 ```js
 useMutation(addTodo, {
@@ -192,7 +194,8 @@ useMutation(addTodo, {
 ['Todo 1', 'Todo 2', 'Todo 3'].forEach((todo) => {
   mutate(todo, {
     onSuccess: (data, error, variables, context) => {
-      // Will execute only once!
+      // Will execute only once, for the last mutation (Todo 3),
+      // regardles which mutation resolves first 
     },
   })
 })

--- a/docs/src/pages/guides/mutations.md
+++ b/docs/src/pages/guides/mutations.md
@@ -179,6 +179,24 @@ mutate(todo, {
 })
 ```
 
+For consequent mutations you may consider passing `onSuccess`, `onError` and `onSettled` to `mutate` function instead of `useMutation`. Then, these callbacks will fire only _once_ after last mutation is fulfilled. It might be useful performance optimisation (ie. when invalidating queries after mutation). This is due to the fact that mutation observer is removed and resubscribed every time when `mutate` function is called.
+
+```js
+useMutation(addTodo, {
+  onSuccess: (data, error, variables, context) => {
+    // Will be called 3 times
+  },
+})
+
+['Todo 1', 'Todo 2', 'Todo 3'].forEach((todo) => {
+  mutate(todo, {
+    onSuccess: (data, error, variables, context) => {
+      // Will execute only once!
+    },
+  })
+})
+
+```
 ## Promises
 
 Use `mutateAsync` instead of `mutate` to get a promise which will resolve on success or throw on an error. This can for example be used to compose side effects.

--- a/docs/src/pages/guides/mutations.md
+++ b/docs/src/pages/guides/mutations.md
@@ -179,6 +179,7 @@ mutate(todo, {
 })
 ```
 
+### Consecutive mutations
 For consecutive mutations, you may consider passing `onSuccess`, `onError` and `onSettled` to the `mutate` function instead of `useMutation`. Then, these callbacks will fire only _once_ after last mutation is fulfilled, and only if the component is still mounted. It might be useful for performance optimisation (ie. when invalidating queries after mutation). This is due to the fact that the mutation observer is removed and resubscribed every time when the `mutate` function is called.
 
 ```js

--- a/docs/src/pages/guides/mutations.md
+++ b/docs/src/pages/guides/mutations.md
@@ -179,7 +179,7 @@ mutate(todo, {
 })
 ```
 
-For consequent mutations you may consider passing `onSuccess`, `onError` and `onSettled` to `mutate` function instead of `useMutation`. Then, these callbacks will fire only _once_ after last mutation is fulfilled. It might be useful performance optimisation (ie. when invalidating queries after mutation). This is due to the fact that mutation observer is removed and resubscribed every time when `mutate` function is called.
+For consecutive mutations, you may consider passing `onSuccess`, `onError` and `onSettled` to the `mutate` function instead of `useMutation`. Then, these callbacks will fire only _once_ after last mutation is fulfilled, and only if the component is still mounted. It might be useful for performance optimisation (ie. when invalidating queries after mutation). This is due to the fact that the mutation observer is removed and resubscribed every time when the `mutate` function is called.
 
 ```js
 useMutation(addTodo, {


### PR DESCRIPTION
Hi Folks!

I just noticed today that there is no explicit mention in Mutations guide about the fact that callbacks passed to `useMutation` will behave slightly different than the ones used in `.mutate`.

There is only small remark about that [here](https://react-query.tanstack.com/reference/useMutation):
> If you make multiple requests, onSuccess will fire only after the latest call you've made.

I hope it may be useful to have this information more visible and that I haven't broken any contribution rules :)