### PR TITLE
Devtools: add code element's backround

### DIFF
--- a/src/devtools/styledComponents.ts
+++ b/src/devtools/styledComponents.ts
@@ -66,6 +66,7 @@ export const QueryKey = styled('span', {
 export const Code = styled('code', {
   fontSize: '.9em',
   color: 'inherit',
+  background: 'inherit',
 })
 
 export const Input = styled('input', (_props, theme) => ({


### PR DESCRIPTION
fix(devtools): Prevent `code` element's backround from being overwritten. This can happen when some global styles are imported in an app (e.g. bootstrap).