### PR TITLE
docs(useQuery): note effect of initialData on loading status

### DIFF
--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -188,7 +188,7 @@ const result = useQuery({
 - `status: String`
   - Will be:
     - `idle` if the query is idle. This only happens if a query is initialized with `enabled: false` and no initial data is available.
-    - `loading` if the query is in a "hard" loading state. This means there is no cached data and the query is currently fetching, eg `isFetching === true`
+    - `loading` if the query is in a "hard" loading state. This means there is no cached data or `initialData` and the query is currently fetching, eg `isFetching === true`
     - `error` if the query attempt resulted in an error. The corresponding `error` property has the error received from the attempted fetch
     - `success` if the query has received a response with no errors and is ready to display its data. The corresponding `data` property on the query is the data received from the successful fetch or if the query's `enabled` property is set to `false` and has not been fetched yet `data` is the first `initialData` supplied to the query on initialization.
 - `isIdle: boolean`


### PR DESCRIPTION
The fact that `initialData` affects `isLoading` during the inital fetch was not clear to me on first read (it will always be `false`).