### PR TITLE
docs: Extend simple example to handle failed request

### DIFF
--- a/examples/simple/src/index.js
+++ b/examples/simple/src/index.js
@@ -18,7 +18,14 @@ function Example() {
   const { isLoading, error, data, isFetching } = useQuery("repoData", () =>
     fetch(
       "https://api.github.com/repos/tannerlinsley/react-query"
-    ).then((res) => res.json())
+    ).then((res) => {
+      // Manually throwing error if request was not successful
+      // https://react-query.tanstack.com/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default
+      if (!res.ok) {
+        throw new Error('Response was not ok')
+      }
+      return res.json()
+    })
   );
 
   if (isLoading) return "Loading...";

--- a/examples/simple/src/index.js
+++ b/examples/simple/src/index.js
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
+import axios from "axios";
 
 const queryClient = new QueryClient();
 
@@ -16,16 +17,9 @@ export default function App() {
 
 function Example() {
   const { isLoading, error, data, isFetching } = useQuery("repoData", () =>
-    fetch(
+    axios.get(
       "https://api.github.com/repos/tannerlinsley/react-query"
-    ).then((res) => {
-      // Manually throwing error if request was not successful
-      // https://react-query.tanstack.com/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default
-      if (!res.ok) {
-        throw new Error('Response was not ok')
-      }
-      return res.json()
-    })
+    ).then((res) => res.data)
   );
 
   if (isLoading) return "Loading...";


### PR DESCRIPTION
Hey there,
I recently stumpled across a [misunderstanding](https://github.com/tannerlinsley/react-query/issues/2258#issuecomment-1034707667) of the library and the [referenced simple example](https://codesandbox.io/s/github/tannerlinsley/react-query/tree/master/examples/simple).
Since the example contains an error handling with respect to the UI, it should also correctly recognize occurring errors. As mentioned in the docs, [fetch and other clients do not throw by default](https://react-query.tanstack.com/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default) an error - so I added the error handling to the example within the result handler.
