### PR TITLE
Update comparison.md

### DIFF
--- a/docs/src/pages/comparison.md
+++ b/docs/src/pages/comparison.md
@@ -23,7 +23,7 @@ Feature/Capability Key:
 | Query Key Change Detection                         | Deep Compare (Stable Serialization)      | Shallow Compare             | Deep Compare (Unstable Serialization) | Referential Equality (===)           |
 | Query Data Change Detection                        | Deep Comparison + Structural Sharing     | Deep Compare (via `dequal`) | Deep Compare (Unstable Serialization) | Referential Equality (===)           |
 | Query Data Memoization Level                       | Query + Structural Sharing               | Query                       | Query + Entity + Structural Sharing   | Query                                |
-| Bundle Size                                        | [![][bp-react-query]][bpl-react-query]   | [![][bp-swr]][bpl-swr]      | [![][bp-apollo]][bpl-apollo]          | [![][bp-rtk-query]][bpl-rtk-query]   |
+| Bundle Size<sup>8</sup>                            | [![][bp-react-query]][bpl-react-query]   | [![][bp-swr]][bpl-swr]      | [![][bp-apollo]][bpl-apollo]          | [![][bp-rtk-query]][bpl-rtk-query]   |
 | API Definition                                     | On-Use, Declarative                      | On-Use                      | GraphQL Schema                        | Declarative                          |
 | Queries                                            | ✅                                       | ✅                          | ✅                                    | ✅                                   |
 | Caching                                            | ✅                                       | ✅                          | ✅                                    | ✅                                   |
@@ -74,7 +74,9 @@ Feature/Capability Key:
 
 > **<sup>6</sup> Normalized Caching** - React Query, SWR and RTK-Query do not currently support automatic-normalized caching which describes storing entities in a flat architecture to avoid some high-level data duplication.
 
-> **<sup>6</sup> SWR's Immutable Mode** - SWR ships with an "immutable" mode that does allow you to only fetch a query once for the life of the cache, but it still does not have the concept of stale-time or conditional auto-revalidation
+> **<sup>7</sup> SWR's Immutable Mode** - SWR ships with an "immutable" mode that does allow you to only fetch a query once for the life of the cache, but it still does not have the concept of stale-time or conditional auto-revalidation
+
+> **<sup>8</sup> RTK-Query's bundle size** [can vary][rtk-query-bundle-size] depending on whether you already use redux-toolkit or not
 
 <!-- -->
 
@@ -103,9 +105,10 @@ Feature/Capability Key:
 
 [rtk-query]: https://redux-toolkit.js.org/rtk-query/overview
 [rtk-query-comparison]: https://redux-toolkit.js.org/rtk-query/comparison
+[rtk-query-bundle-size]: https://redux-toolkit.js.org/rtk-query/comparison#bundle-size
 [bp-rtk]: https://badgen.net/bundlephobia/minzip/@reduxjs/toolkit?label=💾
-[bp-rtk-query]: https://badgen.net/bundlephobia/minzip/@rtk-incubator/rtk-query?label=💾
-[gh-rtk-query]: https://github.com/rtk-incubator/rtk-query
-[stars-rtk-query]: https://img.shields.io/github/stars/rtk-incubator/rtk-query?label=%F0%9F%8C%9F
+[bp-rtk-query]: https://badgen.net/bundlephobia/minzip/@reduxjs/toolkit?label=💾
+[gh-rtk-query]: https://github.com/reduxjs/redux-toolkit
+[stars-rtk-query]: https://img.shields.io/github/stars/reduxjs/redux-toolkit?label=🌟
 [bpl-rtk]: https://bundlephobia.com/result?p=@reduxjs/toolkit
-[bpl-rtk-query]: https://bundlephobia.com/result?p=@rtk-incubator/rtk-query
+[bpl-rtk-query]: https://bundlephobia.com/package/@reduxjs/toolkit


### PR DESCRIPTION
rtk-query stars counter points to an archived repo.

Query now lives in the main repo as a package.

I understand that this isn't totally right, but at least it seems reasonable not to count start of an archived repo.