### PR TITLE
fix(mem): Stop leak from cacheTime outliving Query given WeakRef support (v3)

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -7,6 +7,7 @@ import {
   replaceEqualDeep,
   timeUntilStale,
   ensureQueryKeyArray,
+  CompatWeakRef,
 } from './utils'
 import type {
   InitialDataFunction,
@@ -204,8 +205,10 @@ export class Query<
     this.clearGcTimeout()
 
     if (isValidTimeout(this.cacheTime)) {
+      const thisRef = new CompatWeakRef(this)
+
       this.gcTimeout = setTimeout(() => {
-        this.optionalRemove()
+        thisRef.deref()?.optionalRemove()
       }, this.cacheTime)
     }
   }

--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -920,4 +920,41 @@ describe('query', () => {
 
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
+
+  test.skip('short cacheTime should not let a query self-reference to remain in memory', async () => {
+    let weakQuery
+    let query
+    ;(() => {
+      query = new QueryObserver(new QueryClient(), {
+        queryKey: queryKey(),
+        queryFn: async () => 'data',
+        cacheTime: 3,
+      }).getCurrentQuery()
+
+      weakQuery = new WeakRef(query)
+      query = null
+    })()
+    await sleep(30)
+    // global.gc() // This test needs node to run jest run with --expose-gc
+    expect(query).toBe(null)
+    expect(weakQuery.deref()).toBeUndefined()
+  })
+  test.skip('long cacheTime should not let a query self-reference to remain in memory', async () => {
+    let weakQuery
+    let query
+    ;(() => {
+      query = new QueryObserver(new QueryClient(), {
+        queryKey: queryKey(),
+        queryFn: async () => 'data',
+        cacheTime: 3000,
+      }).getCurrentQuery()
+
+      weakQuery = new WeakRef(query)
+      query = null
+    })()
+    await sleep(30)
+    // global.gc() // This test needs node to run jest run with --expose-gc
+    expect(query).toBe(null)
+    expect(weakQuery.deref()).toBeUndefined()
+  })
 })

--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -921,7 +921,7 @@ describe('query', () => {
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
 
-  test('short cacheTime should not let a query self-reference to remain in memory', async () => {
+  test.skip('short cacheTime should not let a query self-reference to remain in memory', async () => {
     let query
 
     query = new QueryObserver(new QueryClient(), {
@@ -938,7 +938,7 @@ describe('query', () => {
     expect(query).toBe(null)
     expect(weakQuery.deref()).toBeUndefined()
   })
-  test('long cacheTime should not let a query self-reference to remain in memory', async () => {
+  test.skip('long cacheTime should not let a query self-reference to remain in memory', async () => {
     let query
 
     query = new QueryObserver(new QueryClient(), {

--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -921,37 +921,35 @@ describe('query', () => {
     expect(initialDataUpdatedAtSpy).toHaveBeenCalled()
   })
 
-  test.skip('short cacheTime should not let a query self-reference to remain in memory', async () => {
-    let weakQuery
+  test('short cacheTime should not let a query self-reference to remain in memory', async () => {
     let query
-    ;(() => {
-      query = new QueryObserver(new QueryClient(), {
-        queryKey: queryKey(),
-        queryFn: async () => 'data',
-        cacheTime: 3,
-      }).getCurrentQuery()
 
-      weakQuery = new WeakRef(query)
-      query = null
-    })()
+    query = new QueryObserver(new QueryClient(), {
+      queryKey: queryKey(),
+      queryFn: async () => 'data',
+      cacheTime: 3,
+    }).getCurrentQuery()
+
+    const weakQuery = new WeakRef(query)
+    query = null
+
     await sleep(30)
     // global.gc() // This test needs node to run jest run with --expose-gc
     expect(query).toBe(null)
     expect(weakQuery.deref()).toBeUndefined()
   })
-  test.skip('long cacheTime should not let a query self-reference to remain in memory', async () => {
-    let weakQuery
+  test('long cacheTime should not let a query self-reference to remain in memory', async () => {
     let query
-    ;(() => {
-      query = new QueryObserver(new QueryClient(), {
-        queryKey: queryKey(),
-        queryFn: async () => 'data',
-        cacheTime: 3000,
-      }).getCurrentQuery()
 
-      weakQuery = new WeakRef(query)
-      query = null
-    })()
+    query = new QueryObserver(new QueryClient(), {
+      queryKey: queryKey(),
+      queryFn: async () => 'data',
+      cacheTime: 3000,
+    }).getCurrentQuery()
+
+    const weakQuery = new WeakRef(query)
+    query = null
+
     await sleep(30)
     // global.gc() // This test needs node to run jest run with --expose-gc
     expect(query).toBe(null)

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -453,3 +453,19 @@ export function getAbortController(): AbortController | undefined {
     return new AbortController()
   }
 }
+
+/**
+ * Gracefully degrade a WeakRef to a "StrongRef" if support is missing.
+ */
+export const CompatWeakRef =
+  typeof WeakRef === 'function'
+    ? WeakRef
+    : class StrongRef<T extends object> {
+        private target?: T
+        contructor(target: T) {
+          this.target = target
+        }
+        deref() {
+          return this.target
+        }
+      }


### PR DESCRIPTION
This change fixes the issue described in [SSR: High memory consumption on server](https://react-query.tanstack.com/guides/ssr#high-memory-consumption-on-server) in environments with `WeakRef` support (most importantly Node 14.6+). I believe this will allow entire `QueryClient` instances to be garbage collected promptly now, even with `cacheTime`s much longer than the lifetime of the `QueryClient` instance.

I've included a couple of skipped tests that require being run with `--expose-gc` to reproduce the problem and confirm the fix, I didn't want to mess with y'all test setup but there they are.

Cheers
_Io_