### PR TITLE
fix(executeMutation ): don't leave me hanging, please give me a dispatch 

### DIFF
--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -239,6 +239,9 @@ export class Mutation<
       onFail: () => {
         this.dispatch({ type: 'failed' })
       },
+      onError: (error) => {
+        this.dispatch({type: 'error',error: error })
+      }
       onPause: () => {
         this.dispatch({ type: 'pause' })
       },

--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -241,7 +241,7 @@ export class Mutation<
       },
       onError: (error) => {
         this.dispatch({type: 'error',error: error })
-      }
+      },
       onPause: () => {
         this.dispatch({ type: 'pause' })
       },


### PR DESCRIPTION
Currently when an error is thrown such as 500 or 403 using mutation it gets logged and rejected. However, it does not update the mutation cache after error is not resolved. Reject tries to [raise error](https://github.com/tannerlinsley/react-query/blob/7be6d89d689eb61a057d238c95b6701c2a92b7f5/src/core/retryer.ts#L111), however, error is not implemented in executeMutation resulting it being ignored. 

This means that [dispatch ](https://github.com/tannerlinsley/react-query/edit/master/src/core/mutation.ts#L248)is never triggered for error since onError is never implemented till now. Having this enables onError to be executed on retry [when reject happens](https://github.com/tannerlinsley/react-query/blob/7be6d89d689eb61a057d238c95b6701c2a92b7f5/src/core/retryer.ts#L111), which enables full notification of the mutationCache when error happens.

This change in the executeMutation will now dispatch and update the mutation cache on error when retry calls reject which happens on failed request.

Why does this matter? 

As a user if I want to throw error on mutation to an error boundary for example

```
export function useMutationSignUp(....){
  return useMutation(args) =>{
    return postSignUpForm(args);
  },{
    useErrorBoundary:true,
....
```

Is currently not possible without an error being dispatched, dispatching only happens if onError is implemented on the config. executeMutation implementing onError will enable cache to be notified. Resulting in normal react-query behaviour i.e. seeing an error boundary in this case. 