### PR TITLE
fix executeMutation: on error cache gets updated before promise is ev…

### DIFF
--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -190,7 +190,6 @@ export class Mutation<
         )
       )
       .then(() => {
-        this.dispatch({ type: 'success', data })
         return data
       })
       .catch(error => {
@@ -222,7 +221,6 @@ export class Mutation<
             )
           )
           .then(() => {
-            this.dispatch({ type: 'error', error })
             throw error
           })
       })
@@ -235,6 +233,13 @@ export class Mutation<
           return Promise.reject('No mutationFn found')
         }
         return this.options.mutationFn(this.state.variables!)
+      },
+
+      onSuccess: (data) => {
+        this.dispatch({ type: 'success', data })
+      },
+      onError: (error) =>{
+        this.dispatch({ type: 'error', error: error })
       },
       onFail: () => {
         this.dispatch({ type: 'failed' })

--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -190,6 +190,7 @@ export class Mutation<
         )
       )
       .then(() => {
+        this.dispatch({ type: 'success', data })
         return data
       })
       .catch(error => {
@@ -235,9 +236,6 @@ export class Mutation<
         return this.options.mutationFn(this.state.variables!)
       },
 
-      onSuccess: (data) => {
-        this.dispatch({ type: 'success', data })
-      },
       onError: (error) =>{
         this.dispatch({ type: 'error', error: error })
       },

--- a/src/core/tests/mutations.test.tsx
+++ b/src/core/tests/mutations.test.tsx
@@ -78,25 +78,6 @@ describe('mutations', () => {
     expect(cache?.state.error).toEqual(error)
   })
 
-  test('executeMutation should propagate success to the mutation cache after retrier resolves', async () => {
-    const key = queryKey()
-
-    const data = "hello world";
-    queryClient.setMutationDefaults(key, {
-      mutationFn: async () => { return  data},
-      retry: false
-    })
-
-    await queryClient.executeMutation({
-        variables: 'todo',
-        mutationKey: key,
-      })
-
-    const cache = queryClient.getMutationCache().getAll().find(x => x.state.data);
-
-    expect(cache?.state.data).toEqual(data)
-  })
-
   test('mutation should set correct success states', async () => {
     const mutation = new MutationObserver(queryClient, {
       mutationFn: async (text: string) => {


### PR DESCRIPTION
**Desired result: when mutation fails and error boundary is set to true, I want to see the error boundary being triggered.**

Example
```
export function useMutationSignUp(....){
  return useMutation(args) =>{
    return postSignUpForm(args);
  },{
    retry: false,
    useErrorBoundary: true,
....
```

**Issue**

Currently, when an error is triggered it gets [dispatched](https://github.com/tannerlinsley/react-query/blob/master/src/core/mutation.ts#L225) before it is thrown and before the promise is rejected by the retryer. I do lack the domain knowledge to explain why this is a problem, however it is definitely not creating the desired behaviour.

Take for example an application, that has these defaults shown above (`  useErrorBoundary: true,  retry: false,`). Once a post fails i.e. returns a failed request, the expect behaviour would been to throw to the error boundary immediately since retry is also set to false. However, this is not the case. Here is an example application to demonstrate this current behaviour.

![before-fix](https://user-images.githubusercontent.com/96931708/158077904-ce076abf-d09d-4e39-b573-a1f830b76dcd.gif)

Here is the current code base for this application specific [sign up page](https://github.com/Toyotomi-clan/borngladiator/blob/master/apps/born/src/app/signup.tsx) (sorry for the mess)



Initially, I thought no dispatch was being called. This turns out to be false. In line [225](https://github.com/tannerlinsley/react-query/blob/master/src/core/mutation.ts#L225) a dispatch gets called. However, as stated above this happens before the error is thrown or promise is rejected.  Having executeMutation implement error allows the [retryer to raise the error](https://github.com/tannerlinsley/react-query/blob/master/src/core/retryer.ts#L111). 

Doing this results in the desired behaviour.

Ultimately, I am not sure why rising a dispatch at the retryer level results in the desired behaviour while doing so before a throw does not. I welcome any feedback into this.

Here is the working example of the error raising and propagating to the error boundary with the changes implemented. 


![after-fix](https://user-images.githubusercontent.com/96931708/158078898-acc43e19-208d-4984-be11-4f6eee707df5.gif)


