### PR TITLE
fix(devtools): serialize bigint types

### DIFF
--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { styled } from './utils'
+import { displayValue, styled } from './utils'
 
 export const Entry = styled('div', {
   fontFamily: 'Menlo, monospace',
@@ -154,10 +154,7 @@ export const DefaultRenderer: Renderer = ({
         </>
       ) : (
         <>
-          <Label>{label}:</Label>{' '}
-          <Value>
-            {JSON.stringify(value, Object.getOwnPropertyNames(Object(value)))}
-          </Value>
+          <Label>{label}:</Label> <Value>{displayValue(value)}</Value>
         </>
       )}
     </Entry>

--- a/src/devtools/tests/Explorer.test.tsx
+++ b/src/devtools/tests/Explorer.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { chunkArray, DefaultRenderer } from '../Explorer'
+import { displayValue } from '../utils'
 
 describe('Explorer', () => {
   describe('chunkArray', () => {
@@ -53,5 +54,9 @@ describe('Explorer', () => {
 
       expect(toggleExpanded).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('when the value is a BigInt', () => {
+    expect(displayValue(BigInt(1))).toBe('"1n"')
   })
 })

--- a/src/devtools/tests/Explorer.test.tsx
+++ b/src/devtools/tests/Explorer.test.tsx
@@ -56,7 +56,13 @@ describe('Explorer', () => {
     })
   })
 
-  it('when the value is a BigInt', () => {
-    expect(displayValue(BigInt(1))).toBe('"1n"')
+  describe('displayValue', () => {
+    it('when the value is a boolean', () => {
+      expect(displayValue(true)).toBe('true')
+    })
+
+    it('when the value is a BigInt', () => {
+      expect(displayValue(BigInt(1))).toBe('"1n"')
+    })
   })
 })

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -125,14 +125,12 @@ export function useSafeState<T>(initialState: T): [T, (value: T) => void] {
 
 /**
  * Displays a string regardless the type of the data
- * @param {any} value Value to be stringified
+ * @param {unknown} value Value to be stringified
  */
- export const displayValue = (value: any) => {
-  let newValue = value
+export const displayValue = (value: unknown) => {
   const name = Object.getOwnPropertyNames(Object(value))
-  if (typeof value === 'bigint') {
-    newValue = `${value.toString()}n`
-  }
+  const newValue = typeof value === 'bigint' ? `${value.toString()}n` : value
+
   return JSON.stringify(newValue, name)
 }
 

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -124,6 +124,19 @@ export function useSafeState<T>(initialState: T): [T, (value: T) => void] {
 }
 
 /**
+ * Displays a string regardless the type of the data
+ * @param {any} value Value to be stringified
+ */
+ export const displayValue = (value: any) => {
+  let newValue = value
+  const name = Object.getOwnPropertyNames(Object(value))
+  if (typeof value === 'bigint') {
+    newValue = `${value.toString()}n`
+  }
+  return JSON.stringify(newValue, name)
+}
+
+/**
  * Schedules a microtask.
  * This can be useful to schedule state updates after rendering.
  */


### PR DESCRIPTION
closes #3082 

### Detail
I detected the issue `TypeError: Do not know how to serialize a BigInt` was caused by `JSON.stringify` in the devtools explorer. I created a separate function so I could also write a test. 

This is my first contribution here, so please, let me know how I can improve this implementation. 😄
