### PR TITLE
fix(devtools): add keys to mapped entries for Explorer

### DIFF
--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -118,7 +118,7 @@ export const DefaultRenderer: Renderer = ({
             subEntryPages.length === 1 ? (
               <SubEntries>
                 {subEntries.map(entry => (
-                  <HandleEntry entry={entry} />
+                  <HandleEntry key={entry.label} entry={entry} />
                 ))}
               </SubEntries>
             ) : (
@@ -141,7 +141,7 @@ export const DefaultRenderer: Renderer = ({
                       {expandedPages.includes(index) ? (
                         <SubEntries>
                           {entries.map(entry => (
-                            <HandleEntry entry={entry} />
+                            <HandleEntry key={entry.label} entry={entry} />
                           ))}
                         </SubEntries>
                       ) : null}


### PR DESCRIPTION
Added missing key prop to map fns on `Explorer.tsx`


Used `entry.label` as key, which assumes that label is unique

Discovered after converting Explorer component to typescript [here](https://github.com/tannerlinsley/react-query/pull/2949#issuecomment-1078772381)



A way to avoid this issue in the future could be to enable [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)'s [react/jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) rule