### PR TITLE
chore(eslint): Add react/jsx-key lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     "sourceType": "module"
   },
   "rules": {
+    "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",


### PR DESCRIPTION
Rule is set to error.
option checkFragmentShorthand option set to true,  meaning the rule is used for shorthand fragment syntax too.
option will default to true next major eslint-plugin-react version

See rule docs [here](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)