### PR TITLE
chore: allow react v18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "match-sorter": "^6.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "react-dom": {


### PR DESCRIPTION
V18 is finally out, and npm by default warns that packages like `react-query` are not expecting that version.

To my knowledge, the only "breaking" change of v18 is concurrent rendering. I don't _think_ that will impact this library, especially since side effects like observer subscriptions already happen in `useEffect` hooks.

Actually methods like [`batchCalls`](https://github.com/tannerlinsley/react-query/blob/master/src/core/notifyManager.ts#L59) are probably no longer necessary (although for should remain so long as <=17 is supported)