### PR TITLE
docs: Improve readability of `useRefreshOnFocus`

### DIFF
--- a/docs/src/pages/react-native.md
+++ b/docs/src/pages/react-native.md
@@ -55,16 +55,19 @@ import React from 'react'
 import { useFocusEffect } from '@react-navigation/native'
 
 export function useRefreshOnFocus<T>(refetch: () => Promise<T>) {
-  const enabledRef = React.useRef(false)
+  const firstTimeRef = React.useRef(true)
 
   useFocusEffect(
     React.useCallback(() => {
-      if (enabledRef.current) {
-        refetch()
-      } else {
-        enabledRef.current = true
+      if (firstTimeRef.current) {
+         firstTimeRef.current = false;
+         return;
       }
+
+      refetch()
     }, [refetch])
   )
 }
 ```
+
+In the above code, `refetch` is skipped the first time because `useFocusEffect` calls our callback on mount in addition to screen focus.


### PR DESCRIPTION
It was not obvious what `useRefreshOnFocus` hook does at first glance. This PR refactors it to use a `firstTimeRef` ref to make it clear that we are skipping the first time `useFocusEffect` is called.