### PR TITLE
fix: change devtools env condition

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -1,4 +1,4 @@
-if (process.env.NODE_ENV !== 'development') {
+if (process.env.NODE_ENV === 'production') {
   module.exports = {
     ReactQueryDevtools: function () {
       return null


### PR DESCRIPTION
We basically use process.env.NODE_ENV as 'localhost', so devtools does not work.

So I changed the devtools conditional statement. Please check it out.