### PR TITLE
fix: Add explicit PropsWithChildren to resolve React 18 typedef change

### DIFF
--- a/src/react/QueryClientProvider.tsx
+++ b/src/react/QueryClientProvider.tsx
@@ -46,7 +46,7 @@ export interface QueryClientProviderProps {
   contextSharing?: boolean
 }
 
-export const QueryClientProvider: React.FC<QueryClientProviderProps> = ({
+export const QueryClientProvider: React.FC<React.PropsWithChildren<QueryClientProviderProps>> = ({
   client,
   contextSharing = false,
   children,


### PR DESCRIPTION
>Due to changes in the React18 typedefs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
We plan to remove implicit children from @types/react. 

Relates to #3476 