### PR TITLE
fix: 🐛 make types @types/react@18 compatible

### DIFF
--- a/src/react/Hydrate.tsx
+++ b/src/react/Hydrate.tsx
@@ -25,7 +25,7 @@ export interface HydrateProps {
   options?: HydrateOptions
 }
 
-export const Hydrate: React.FC<HydrateProps> = ({
+export const Hydrate: React.FC<React.PropsWithChildren<HydrateProps>> = ({
   children,
   options,
   state,

--- a/src/react/QueryClientProvider.tsx
+++ b/src/react/QueryClientProvider.tsx
@@ -46,11 +46,9 @@ export interface QueryClientProviderProps {
   contextSharing?: boolean
 }
 
-export const QueryClientProvider: React.FC<QueryClientProviderProps> = ({
-  client,
-  contextSharing = false,
-  children,
-}) => {
+export const QueryClientProvider: React.FC<
+  React.PropsWithChildren<QueryClientProviderProps>
+> = ({ client, contextSharing = false, children }) => {
   React.useEffect(() => {
     client.mount()
     return () => {

--- a/src/react/QueryErrorResetBoundary.tsx
+++ b/src/react/QueryErrorResetBoundary.tsx
@@ -38,9 +38,9 @@ export interface QueryErrorResetBoundaryProps {
     | React.ReactNode
 }
 
-export const QueryErrorResetBoundary: React.FC<QueryErrorResetBoundaryProps> = ({
-  children,
-}) => {
+export const QueryErrorResetBoundary: React.FC<
+  React.PropsWithChildren<QueryErrorResetBoundaryProps>
+> = ({ children }) => {
   const value = React.useMemo(() => createValue(), [])
   return (
     <QueryErrorResetBoundaryContext.Provider value={value}>

--- a/src/react/tests/utils.tsx
+++ b/src/react/tests/utils.tsx
@@ -67,7 +67,7 @@ export const expectType = <T,>(_: T): void => undefined
 export const expectTypeNotAny = <T,>(_: 0 extends 1 & T ? never : T): void =>
   undefined
 
-export const Blink: React.FC<{ duration: number }> = ({
+export const Blink: React.FC<React.PropsWithChildren<{ duration: number }>> = ({
   duration,
   children,
 }) => {


### PR DESCRIPTION
In react 18 types children was removed from FC type.

Changes of this PR are compatible with 17 and 18 typings versions.