### PR TITLE
fix(types): fix promise inference in useQueries

### DIFF
--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -803,7 +803,8 @@ describe('query', () => {
 
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
-      queryFn: (() => undefined) as any,
+      // @ts-expect-error (queryFn must not return undefined)
+      queryFn: (() => undefined),
       retry: false,
     })
 

--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -804,7 +804,7 @@ describe('query', () => {
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
       // @ts-expect-error (queryFn must not return undefined)
-      queryFn: (() => undefined),
+      queryFn: () => undefined,
       retry: false,
     })
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,7 +14,7 @@ export type QueryFunction<
   TQueryKey extends QueryKey = QueryKey
 > = (
   context: QueryFunctionContext<TQueryKey>
-) => QueryFunctionData<T> | Promise<QueryFunctionData<T>>
+) => QueryFunctionData<T | Promise<T>>
 
 export interface QueryFunctionContext<
   TQueryKey extends QueryKey = QueryKey,
@@ -106,7 +106,7 @@ export interface QueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
+>  extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -106,7 +106,7 @@ export interface QueryObserverOptions<
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
->  extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
+> extends QueryOptions<TQueryFnData, TError, TQueryData, TQueryKey> {
   /**
    * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
    * To refetch the query, use the `refetch` method returned from the `useQuery` instance.

--- a/src/persistQueryClient/tests/PersistQueryClientProvider.test.tsx
+++ b/src/persistQueryClient/tests/PersistQueryClientProvider.test.tsx
@@ -147,7 +147,7 @@ describe('PersistQueryClientProvider', () => {
 
       return (
         <div>
-          <h1>{String(state.data)}</h1>
+          <h1>{state.data}</h1>
           <h2>fetchStatus: {state.fetchStatus}</h2>
         </div>
       )

--- a/src/reactjs/tests/useQueries.test.tsx
+++ b/src/reactjs/tests/useQueries.test.tsx
@@ -776,8 +776,25 @@ describe('useQueries', () => {
       expectType<QueryObserverResult<string, unknown>>(result4[1])
       expectType<QueryObserverResult<number, unknown>>(result4[2])
 
-      // Array as const does not throw error
+      // handles when queryFn returns a Promise
       const result5 = useQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => Promise.resolve('string'),
+            onSuccess: (a: string) => {
+              expectType<string>(a)
+              expectTypeNotAny(a)
+            },
+            // @ts-expect-error (refuses to accept a Promise)
+            onSettled: (a: Promise<string>) => null,
+          },
+        ],
+      })
+      expectType<QueryObserverResult<string, unknown>>(result5[0])
+
+      // Array as const does not throw error
+      const result6 = useQueries({
         queries: [
           {
             queryKey: ['key1'],
@@ -789,8 +806,8 @@ describe('useQueries', () => {
           },
         ],
       } as const)
-      expectType<QueryObserverResult<string, unknown>>(result5[0])
-      expectType<QueryObserverResult<number, unknown>>(result5[1])
+      expectType<QueryObserverResult<string, unknown>>(result6[0])
+      expectType<QueryObserverResult<number, unknown>>(result6[1])
 
       // field names should be enforced - array literal
       useQueries({

--- a/src/reactjs/tests/useQuery.test.tsx
+++ b/src/reactjs/tests/useQuery.test.tsx
@@ -38,6 +38,10 @@ describe('useQuery', () => {
       expectType<unknown>(noQueryFn.data)
       expectType<unknown>(noQueryFn.error)
 
+      // it should not be possible for queryFn to return undefined
+      // @ts-expect-error (queryFn returns undefined)
+      useQuery(key, () => undefined)
+
       // it should infer the result type from the query function
       const fromQueryFn = useQuery(key, () => 'test')
       expectType<string | undefined>(fromQueryFn.data)


### PR DESCRIPTION
fixes issue #3483 

This new helper `QueryFunctionData` was introduced in the latest branch:

```typescript
type QueryFunctionData<T> = T extends undefined ? never : T

type QueryFunction<
  T = unknown,
  TQueryKey extends QueryKey = QueryKey
> = (
  context: QueryFunctionContext<TQueryKey>
) => QueryFunctionData<T> | Promise<QueryFunctionData<T>>
```

Looks like when a conditional expression is duplicated like this in a union, it's not able to pass along any `infer` logic correctly.

[(TS Playground link with a simplified example - not restricted to promises though... you can replace `Promise<X>` with `Array<X>` for the same effect)](https://www.typescriptlang.org/play?#code/C4TwDgpgBAigrhATiAYnAdgY2ASwPboAiAhsMQDwAqAfFALxSVQQAewE6AJgM5QacQAZjnQROUAPxRRANyRQAXIwBQy0JCgB5OO0QBVdPnRVaDeElQZsRkmRNQAPlAAKiPAFsc3COXPI0WLgEthQ01Grg0ACS6IJIetwiAObauvYMTKzsXLyp8YYE5CJxiIx+ICG0UpTlIYrSEHKIERooxDgANvRQMSUJyXmI5K4eXj7cwIjJ1OGYBBNQgu0dShNT6EndAOTcHhDAABbJW1DEvG2dqurR6KL6BcY03eUB1sGkoY4ubp7eJuHXHqxeKJDYxO7pRjMNgcHhAu4GIxFYGlGoIZCVSRldEVD71WRIFrQZxnXgMXog5LgpDDH5jchraazebAKBgUmrSbJba7dz7I4bE5nFykoA)

This means the `useQueries` helper types are getting confused, thinking `TQueryFnData` could itself be a promise.

Interestingly, if we make it so there's only 1 instance of `QueryFunctionData`, with a union as its type argument, as I'm doing in this PR, it seems to work just fine. [Rules of TS claim that the two expressions should be equivalent](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types), so it's a bit counter-intuitive that 1 way works and the other doesn't.

So my hunch is that the issue was caused by how TS goes about evaluating... when it's doing inference on a union of two nested conditional expressions, it may be evaluating twice, and merges the results together, meaning we end up with both `string` and `Promise<string>` that fit the bill.

 (I'm asking around to get a better understanding of the mechanics - will let you know if it's caused by something else).


