### PR TITLE
fix: type QueryClientProvider children explicitly

### DIFF
--- a/src/react/QueryClientProvider.tsx
+++ b/src/react/QueryClientProvider.tsx
@@ -42,6 +42,7 @@ export const useQueryClient = () => {
 }
 
 export interface QueryClientProviderProps {
+  children?: React.ReactNode
   client: QueryClient
   contextSharing?: boolean
 }


### PR DESCRIPTION
[React 18 introduced some breaking type changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210). One is that `children` is no longer implicitly typed with `React.FC`. This breaks `QueryClientProvider`, since it relies on implicit children through `React.FC`. It can be fixed by typing it explicitly, while it will be no change for users of React 17 or lower.