### PR TITLE
FailureCount resest,

### DIFF
--- a/docs/src/pages/reference/useQuery.md
+++ b/docs/src/pages/reference/useQuery.md
@@ -235,6 +235,7 @@ const result = useQuery({
   - The failure count for the query.
   - Incremented every time the query fails.
   - Reset to `0` when the query succeeds.
+  - Reset to `0` when refetchInterval is invoked.
 - `refetch: (options: { throwOnError: boolean, cancelRefetch: boolean }) => Promise<UseQueryResult>`
   - A function to manually refetch the query.
   - If the query errors, the error will only be logged. If you want an error to be thrown, pass the `throwOnError: true` option

--- a/src/core/mutation.ts
+++ b/src/core/mutation.ts
@@ -247,6 +247,7 @@ export class Mutation<
       },
       retry: this.options.retry ?? 0,
       retryDelay: this.options.retryDelay,
+      failureCount: this.state.failureCount,
     })
 
     return this.retryer.promise

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -459,6 +459,7 @@ export class Query<
     // Try to fetch the data
     this.retryer = new Retryer({
       fn: context.fetchFn as () => TData,
+      failureCount: this.state.fetchFailureCount,
       abort: abortController?.abort?.bind(abortController),
       onSuccess: data => {
         this.setData(data as TData)

--- a/src/core/retryer.ts
+++ b/src/core/retryer.ts
@@ -15,6 +15,7 @@ interface RetryerConfig<TData = unknown, TError = unknown> {
   onContinue?: () => void
   retry?: RetryValue<TError>
   retryDelay?: RetryDelayValue<TError>
+  failureCount: number
 }
 
 export type RetryValue<TError> = boolean | number | ShouldRetryFunction<TError>
@@ -87,7 +88,7 @@ export class Retryer<TData = unknown, TError = unknown> {
       cancelRetry = false
     }
     this.continue = () => continueFn?.()
-    this.failureCount = 0
+    this.failureCount = config.failureCount
     this.isPaused = false
     this.isResolved = false
     this.isTransportCancelable = false


### PR DESCRIPTION
Hey!

I have noticed that "failureCount"  is resetting in useQuery
when refetch interval is invoked. if it's intended I didn't find it in the DOCS -  ( Added it )

I tried to fix it unsuccessfully, still not clear if a fix is needed 😅 

Thanks!
