### PR TITLE
feat(types): make QueryClientConfig generic

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -676,10 +676,10 @@ export type MutationObserverResult<
   | MutationObserverErrorResult<TData, TError, TVariables, TContext>
   | MutationObserverSuccessResult<TData, TError, TVariables, TContext>
 
-export interface QueryClientConfig {
+export interface QueryClientConfig<TError = unknown> {
   queryCache?: QueryCache
   mutationCache?: MutationCache
-  defaultOptions?: DefaultOptions
+  defaultOptions?: DefaultOptions<TError>
 }
 
 export interface DefaultOptions<TError = unknown> {


### PR DESCRIPTION
Add type argument for `QueryClientConfig` generic type.

Please see discussion #3528 for detailed explanation.