### PR TITLE
fix(devtools): Fix expand button styling

### DIFF
--- a/src/devtools/Explorer.tsx
+++ b/src/devtools/Explorer.tsx
@@ -19,6 +19,16 @@ export const LabelButton = styled('button', {
   color: 'white',
 })
 
+export const ExpandButton = styled('button', {
+  cursor: 'pointer',
+  color: 'inherit',
+  font: 'inherit',
+  outline: 'inherit',
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+})
+
 export const Value = styled('span', (_props, theme) => ({
   color: theme.danger,
 }))
@@ -107,13 +117,13 @@ export const DefaultRenderer: Renderer = ({
     <Entry key={label}>
       {subEntryPages?.length ? (
         <>
-          <button onClick={() => toggleExpanded()}>
+          <ExpandButton onClick={() => toggleExpanded()}>
             <Expander expanded={expanded} /> {label}{' '}
             <Info>
               {String(type).toLowerCase() === 'iterable' ? '(Iterable) ' : ''}
               {subEntries.length} {subEntries.length > 1 ? `items` : `item`}
             </Info>
-          </button>
+          </ExpandButton>
           {expanded ? (
             subEntryPages.length === 1 ? (
               <SubEntries>


### PR DESCRIPTION
Adds `ExpandButton` component for styling the expand button correctly (removes browser default styles)

Before:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/14815230/164612944-c4d25d00-58de-4a0d-967e-350d8363e06a.png">


After:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/14815230/164612710-4ac930a8-06a6-41f3-85e9-23bb89258dbb.png">


closes #3538