### PR TITLE
feat: make InfiniteQueryObserver's type more robust

### DIFF
--- a/src/core/infiniteQueryBehavior.ts
+++ b/src/core/infiniteQueryBehavior.ts
@@ -173,7 +173,7 @@ export function getPreviousPageParam(
  * Returns `undefined` if it cannot be determined.
  */
 export function hasNextPage(
-  options: QueryOptions<any, any>,
+  options: QueryOptions<any, any, any, any>,
   pages?: unknown
 ): boolean | undefined {
   if (options.getNextPageParam && Array.isArray(pages)) {
@@ -191,7 +191,7 @@ export function hasNextPage(
  * Returns `undefined` if it cannot be determined.
  */
 export function hasPreviousPage(
-  options: QueryOptions<any, any>,
+  options: QueryOptions<any, any, any, any>,
   pages?: unknown
 ): boolean | undefined {
   if (options.getPreviousPageParam && Array.isArray(pages)) {

--- a/src/core/infiniteQueryObserver.ts
+++ b/src/core/infiniteQueryObserver.ts
@@ -5,6 +5,7 @@ import type {
   InfiniteData,
   InfiniteQueryObserverOptions,
   InfiniteQueryObserverResult,
+  QueryKey,
 } from './types'
 import type { QueryClient } from './queryClient'
 import {
@@ -27,12 +28,14 @@ export class InfiniteQueryObserver<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
-  TQueryData = TQueryFnData
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
 > extends QueryObserver<
   TQueryFnData,
   TError,
   InfiniteData<TData>,
-  InfiniteData<TQueryData>
+  InfiniteData<TQueryData>,
+  TQueryKey
 > {
   // Type override
   subscribe!: (
@@ -54,7 +57,8 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      TQueryKey
     >
   ) {
     super(client, options)
@@ -71,7 +75,8 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      TQueryKey
     >,
     notifyOptions?: NotifyOptions
   ): void {
@@ -89,7 +94,8 @@ export class InfiniteQueryObserver<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      TQueryKey
     >
   ): InfiniteQueryObserverResult<TData, TError> {
     options.behavior = infiniteQueryBehavior()
@@ -125,12 +131,13 @@ export class InfiniteQueryObserver<
   }
 
   protected createResult(
-    query: Query<TQueryFnData, TError, InfiniteData<TQueryData>>,
+    query: Query<TQueryFnData, TError, InfiniteData<TQueryData>, TQueryKey>,
     options: InfiniteQueryObserverOptions<
       TQueryFnData,
       TError,
       TData,
-      TQueryData
+      TQueryData,
+      TQueryKey
     >
   ): InfiniteQueryObserverResult<TData, TError> {
     const { state } = query


### PR DESCRIPTION
Currently i face with this problem that i defined a `InfiniteQueryObserverOptions` that contains `QueryKey`. and then i pass it into `InfiniteQueryObserver`. but unfortunately its not compatible with options of  `InfiniteQueryObserver`'s constructor