### PR TITLE
docs: Remove react-native-appstate-hook

### DIFF
--- a/docs/src/pages/react-native.md
+++ b/docs/src/pages/react-native.md
@@ -28,11 +28,9 @@ onlineManager.setEventListener(setOnline => {
 ## Refetch on App focus
 
 In React Native you have to use React Query `focusManager` to refetch when the App is focused.
-You can use 'react-native-appstate-hook' to be notified when the App state has changed.
 
 ```ts
 import { focusManager } from 'react-query'
-import useAppState from 'react-native-appstate-hook'
 
 function onAppStateChange(status: AppStateStatus) {
   if (Platform.OS !== 'web') {
@@ -40,9 +38,11 @@ function onAppStateChange(status: AppStateStatus) {
   }
 }
 
-useAppState({
-  onChange: onAppStateChange,
-})
+useEffect(() => {
+  const subscription = AppState.addEventListener('change', onAppStateChange)
+
+  return () => subscription.remove()
+}, [])
 ```
 
 ## Refresh on Screen focus


### PR DESCRIPTION
- [react-native-appstate-hook](https://github.com/amrlabib/react-native-appstate-hook) is not updated regularly. It currently has a `peerDependencies` problem for React 17 and 18.
- It actually does the same thing with `AppState.addEventListener('change', ...)` when you only specify `onChange` property on `useAppState()`.