### PR TITLE
fix(queryClient): make sure that setQueryData can return undefined from the updater function on type level

### DIFF
--- a/src/core/queryClient.ts
+++ b/src/core/queryClient.ts
@@ -128,7 +128,7 @@ export class QueryClient {
 
   setQueryData<TData>(
     queryKey: QueryKey,
-    updater: Updater<TData | undefined, TData> | undefined,
+    updater: Updater<TData | undefined, TData | undefined>,
     options?: SetDataOptions
   ): TData | undefined {
     const query = this.queryCache.find<TData>(queryKey)

--- a/src/core/tests/queryClient.test.tsx
+++ b/src/core/tests/queryClient.test.tsx
@@ -311,8 +311,8 @@ describe('queryClient', () => {
 
     test('should not update query data if updater returns undefined', () => {
       const key = queryKey()
-      queryClient.setQueryData(key, 'qux')
-      queryClient.setQueryData(key, () => undefined)
+      queryClient.setQueryData<string>(key, 'qux')
+      queryClient.setQueryData<string>(key, () => undefined)
       expect(queryClient.getQueryData(key)).toBe('qux')
     })
 


### PR DESCRIPTION
the only runtime tests we had didn't use the previous value, so the generic defaults to unknown; the TS error becomes apparent when providing a generic to setQueryData