### PR TITLE
Dates should compare properly

### DIFF
--- a/src/core/tests/utils.test.tsx
+++ b/src/core/tests/utils.test.tsx
@@ -93,7 +93,12 @@ describe('core/utils', () => {
       const b = { a: { b: 'b' }, c: 'c', d: [] }
       expect(partialDeepEqual(a, b)).toEqual(true)
     })
+    it('should return true if a and b are dates', () => {
+      const a = { a: new Date('December 17, 1995 03:24:00') }
+      const b = { a: new Date('December 17, 1995 03:24:00') }
 
+      expect(partialDeepEqual(a, b)).toEqual(true)
+    })
     it('should return `false` if a does not include b', () => {
       const a = { a: { b: 'b' }, c: 'c', d: [] }
       const b = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
@@ -140,9 +145,16 @@ describe('core/utils', () => {
       expect(replaceEqualDeep(null, null)).toBe(null)
       expect(replaceEqualDeep(undefined, undefined)).toBe(undefined)
     })
+
+    it('should return the previous value when the next value is an equal Date', () => {
+      const a = new Date('December 17, 1995 03:24:00')
+      const b = new Date('December 17, 1995 03:24:00')
+      expect(replaceEqualDeep(a, b)).toBe(a)
+    })
+
     it('should return the next value when the previous value is a different value', () => {
-      const date1 = new Date()
-      const date2 = new Date()
+      const date1 = new Date('December 17, 1995 03:24:00')
+      const date2 = new Date('December 18, 1995 03:24:00')
       expect(replaceEqualDeep(1, 0)).toBe(0)
       expect(replaceEqualDeep(1, 2)).toBe(2)
       expect(replaceEqualDeep('1', '2')).toBe('2')

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -369,6 +369,10 @@ export function replaceEqualDeep(a: any, b: any): any {
     return aSize === bSize && equalItems === aSize ? a : copy
   }
 
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime() ? a : b
+  }
+
   return b
 }
 


### PR DESCRIPTION
Hi. I noticed that Date comparisons for `replaceEqualDeep` weren't working and weren't congruent with how `partialDeepEqual` was working.

I added a test to show what `partialDeepEqual` does with Dates (properly returns true if Dates are equivalent)

I then added a test and implementation for a Date comparison. It isn't the same comparison for partialDeepEqual, but I think its equivalent for dates. 
