### PR TITLE
fix(persist): remove environment check

### DIFF
--- a/docs/src/pages/plugins/persistQueryClient.md
+++ b/docs/src/pages/plugins/persistQueryClient.md
@@ -31,9 +31,6 @@ const queryClient = new QueryClient({
 })
 ```
 
-### Environment Checking
-A check for window `undefined` is performed prior to saving/restoring/removing your data (avoids build errors).
-
 ### Cache Busting
 
 Sometimes you may make changes to your application or data that immediately invalidate any and all cached data. If and when this happens, you can pass a `buster` string option. If the cache that is found does not also have that buster string, it will be discarded.  The following several functions accept this option:

--- a/src/createAsyncStoragePersister/index.ts
+++ b/src/createAsyncStoragePersister/index.ts
@@ -15,7 +15,9 @@ export type AsyncPersistRetryer = (props: {
 }) => Promisable<PersistedClient | undefined>
 
 interface CreateAsyncStoragePersisterOptions {
-  /** The storage client used for setting an retrieving items from cache */
+  /** The storage client used for setting and retrieving items from cache.
+   * For SSR pass in `undefined`.
+   */
   storage: AsyncStorage | undefined
   /** The key to use when storing the cache */
   key?: string

--- a/src/createWebStoragePersister/index.ts
+++ b/src/createWebStoragePersister/index.ts
@@ -6,7 +6,9 @@ import {
 } from '../persistQueryClient'
 
 interface CreateWebStoragePersisterOptions {
-  /** The storage client used for setting and retrieving items from cache */
+  /** The storage client used for setting and retrieving items from cache.
+   * For SSR pass in `undefined`.
+   */
   storage: Storage | undefined
   /** The key to use when storing the cache */
   key?: string

--- a/src/persistQueryClient/persist.ts
+++ b/src/persistQueryClient/persist.ts
@@ -66,34 +66,32 @@ export async function persistQueryClientRestore({
   buster = '',
   hydrateOptions,
 }: PersistedQueryClientRestoreOptions) {
-  if (typeof window !== 'undefined') {
-    try {
-      const persistedClient = await persister.restoreClient()
+  try {
+    const persistedClient = await persister.restoreClient()
 
-      if (persistedClient) {
-        if (persistedClient.timestamp) {
-          const expired = Date.now() - persistedClient.timestamp > maxAge
-          const busted = persistedClient.buster !== buster
-          if (expired || busted) {
-            persister.removeClient()
-          } else {
-            hydrate(queryClient, persistedClient.clientState, hydrateOptions)
-          }
-        } else {
+    if (persistedClient) {
+      if (persistedClient.timestamp) {
+        const expired = Date.now() - persistedClient.timestamp > maxAge
+        const busted = persistedClient.buster !== buster
+        if (expired || busted) {
           persister.removeClient()
+        } else {
+          hydrate(queryClient, persistedClient.clientState, hydrateOptions)
         }
+      } else {
+        persister.removeClient()
       }
-    } catch (err) {
-      if (process.env.NODE_ENV !== 'production') {
-        queryClient.getLogger().error(err)
-        queryClient
-          .getLogger()
-          .warn(
-            'Encountered an error attempting to restore client cache from persisted location. As a precaution, the persisted cache will be discarded.'
-          )
-      }
-      persister.removeClient()
     }
+  } catch (err) {
+    if (process.env.NODE_ENV !== 'production') {
+      queryClient.getLogger().error(err)
+      queryClient
+        .getLogger()
+        .warn(
+          'Encountered an error attempting to restore client cache from persisted location. As a precaution, the persisted cache will be discarded.'
+        )
+    }
+    persister.removeClient()
   }
 }
 
@@ -108,15 +106,13 @@ export async function persistQueryClientSave({
   buster = '',
   dehydrateOptions,
 }: PersistedQueryClientSaveOptions) {
-  if (typeof window !== 'undefined') {
-    const persistClient: PersistedClient = {
-      buster,
-      timestamp: Date.now(),
-      clientState: dehydrate(queryClient, dehydrateOptions),
-    }
-
-    await persister.persistClient(persistClient)
+  const persistClient: PersistedClient = {
+    buster,
+    timestamp: Date.now(),
+    clientState: dehydrate(queryClient, dehydrateOptions),
   }
+
+  await persister.persistClient(persistClient)
 }
 
 /**
@@ -157,17 +153,13 @@ export function persistQueryClient(
     persistQueryClientUnsubscribe?.()
   }
 
-  let restorePromise = Promise.resolve()
-
-  if (typeof window !== 'undefined') {
-    // Attempt restore
-    restorePromise = persistQueryClientRestore(props).then(() => {
-      if (!hasUnsubscribed) {
-        // Subscribe to changes in the query cache to trigger the save
-        persistQueryClientUnsubscribe = persistQueryClientSubscribe(props)
-      }
-    })
-  }
+  // Attempt restore
+  const restorePromise = persistQueryClientRestore(props).then(() => {
+    if (!hasUnsubscribed) {
+      // Subscribe to changes in the query cache to trigger the save
+      persistQueryClientUnsubscribe = persistQueryClientSubscribe(props)
+    }
+  })
 
   return [unsubscribe, restorePromise]
 }


### PR DESCRIPTION
because we can now pass in undefined for persisters during SSR, and the persisters themselves are not window related anymore, as we don't use window.localStorage directly