### PR TITLE
fix(types): remove non-void constraint from queryFn result

### DIFF
--- a/src/core/tests/query.test.tsx
+++ b/src/core/tests/query.test.tsx
@@ -810,7 +810,6 @@ describe('query', () => {
 
     const observer = new QueryObserver(queryClient, {
       queryKey: key,
-      // @ts-expect-error (queryFn must not return undefined)
       queryFn: () => undefined,
       retry: false,
     })

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,13 +11,7 @@ export type QueryKey = readonly unknown[]
 export type QueryFunction<
   T = unknown,
   TQueryKey extends QueryKey = QueryKey
-> = (
-  context: QueryFunctionContext<TQueryKey>
-) => [T] extends [undefined]
-  ? never | 'queryFn must not return undefined or void'
-  : [T] extends [void]
-  ? never | 'queryFn must not return undefined or void'
-  : T | Promise<T>
+> = (context: QueryFunctionContext<TQueryKey>) => T | Promise<T>
 
 export interface QueryFunctionContext<
   TQueryKey extends QueryKey = QueryKey,

--- a/src/reactjs/tests/useQueries.test.tsx
+++ b/src/reactjs/tests/useQueries.test.tsx
@@ -607,76 +607,6 @@ describe('useQueries', () => {
     // @ts-expect-error (Page component is not rendered)
     // eslint-disable-next-line
     function Page() {
-      // Rejects queryFn that returns/resolved to undefined or void
-      // @ts-expect-error (queryFn must not return undefined)
-      useQueries({ queries: [{ queryKey: key1, queryFn: () => undefined }] })
-      // @ts-expect-error (queryFn must not return void)
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      useQueries({ queries: [{ queryKey: key1, queryFn: () => {} }] })
-
-      useQueries({
-        // @ts-expect-error (queryFn must not return explicitly undefined)
-        queries: [{ queryKey: key1, queryFn: (): undefined => undefined }],
-      })
-
-      useQueries({
-        // @ts-expect-error (queryFn must not return explicitly void)
-        queries: [{ queryKey: key1, queryFn: (): void => undefined }],
-      })
-
-      useQueries({
-        // @ts-expect-error (queryFn must not return explicitly Promise<void>)
-        queries: [{ queryKey: key1, queryFn: (): Promise<void> => undefined }],
-      })
-
-      useQueries({
-        queries: [
-          // @ts-expect-error (queryFn must not return explicitly Promise<undefined>)
-          { queryKey: key1, queryFn: (): Promise<undefined> => undefined },
-        ],
-      })
-      useQueries({
-        queries: [
-          // @ts-expect-error (queryFn must not return Promise<undefined>)
-          { queryKey: key2, queryFn: () => Promise.resolve(undefined) },
-        ],
-      })
-      useQueries({
-        // @ts-expect-error (queryFn must not return Promise<undefined>)
-        queries: Array(50).map((_, i) => ({
-          queryKey: ['key', i] as const,
-          queryFn: () => Promise.resolve(undefined),
-        })),
-      })
-
-      // Rejects queryFn that always throws
-      useQueries({
-        queries: [
-          // @ts-expect-error (queryFn must not return undefined)
-          {
-            queryKey: key3,
-            queryFn: async () => {
-              throw new Error('')
-            },
-          },
-        ],
-      })
-
-      // Accepts queryFn that *sometimes* throws
-      useQueries({
-        queries: [
-          {
-            queryKey: key3,
-            queryFn: async () => {
-              if (Math.random() > 0.1) {
-                throw new Error('')
-              }
-              return 'result'
-            },
-          },
-        ],
-      })
-
       // Array.map preserves TQueryFnData
       const result1 = useQueries({
         queries: Array(50).map((_, i) => ({
@@ -897,6 +827,37 @@ describe('useQueries', () => {
         queries: Array(10).map(() => ({
           someInvalidField: '',
         })),
+      })
+
+      // field names should be enforced - array literal
+      useQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () => 'string',
+            // @ts-expect-error (invalidField)
+            someInvalidField: [],
+          },
+        ],
+      })
+
+      // supports queryFn using fetch() to return Promise<any> - Array.map() result
+      useQueries({
+        queries: Array(50).map((_, i) => ({
+          queryKey: ['key', i] as const,
+          queryFn: () => fetch('return Promise<any>').then(resp => resp.json()),
+        })),
+      })
+
+      // supports queryFn using fetch() to return Promise<any> - array literal
+      useQueries({
+        queries: [
+          {
+            queryKey: key1,
+            queryFn: () =>
+              fetch('return Promise<any>').then(resp => resp.json()),
+          },
+        ],
       })
     }
   })

--- a/src/reactjs/useQueries.ts
+++ b/src/reactjs/useQueries.ts
@@ -17,10 +17,6 @@ type UseQueryOptionsForUseQueries<
   TQueryKey extends QueryKey = QueryKey
 > = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'context'>
 
-type InvalidQueryFn = QueryFunction<
-  undefined | Promise<undefined> | void | Promise<void>
->
-
 // Avoid TS depth-limit error in case of large array literal
 type MAXIMUM_DEPTH = 20
 
@@ -44,9 +40,7 @@ type GetOptions<T> =
     : T extends [infer TQueryFnData]
     ? UseQueryOptionsForUseQueries<TQueryFnData>
     : // Part 3: responsible for inferring and enforcing type if no explicit parameter was provided
-    T extends { queryFn?: InvalidQueryFn }
-    ? never | 'queryFn must not return undefined or void'
-    : T extends {
+    T extends {
         queryFn?: QueryFunction<infer TQueryFnData, infer TQueryKey>
         select: (data: any) => infer TData
       }
@@ -106,9 +100,7 @@ export type QueriesOptions<
   ? T
   : // If T is *some* array but we couldn't assign unknown[] to it, then it must hold some known/homogenous type!
   // use this to infer the param types in the case of Array.map() argument
-  T extends { queryFn: InvalidQueryFn }[]
-  ? (never | 'queryFn must not return undefined or void')[]
-  : T extends UseQueryOptionsForUseQueries<
+  T extends UseQueryOptionsForUseQueries<
       infer TQueryFnData,
       infer TError,
       infer TData,


### PR DESCRIPTION
discussed in #3541 

trying to enforce not-void + not-undefined on the queryFn return type is creating pockets of complexity / unexpected typing behaviour, as TS is trying to both enforce and infer too many things at the same time.

removing for now, and adding some additional tests to check for the pieces that were clashing with the non-void constraint
- able to use fetch() in queryFn with `Promise<any>` return type
- able to use wrapped queries with custom fetcher functions typed to return `TQueryFnData`