### PR TITLE
fix: `replaceDeepEqual` special case for non-plain arrays

### DIFF
--- a/src/core/tests/utils.test.tsx
+++ b/src/core/tests/utils.test.tsx
@@ -6,6 +6,7 @@ import {
   matchMutation,
   scheduleMicrotask,
   sleep,
+  isPlainArray,
 } from '../utils'
 import { Mutation } from '../mutation'
 import { createQueryClient } from '../../tests/utils'
@@ -53,6 +54,16 @@ describe('core/utils', () => {
       }
 
       expect(isPlainObject(Object.create(Graph))).toBeFalsy()
+    })
+  })
+
+  describe('isPlainArray', () => {
+    it('should return `true` for plain arrays', () => {
+      expect(isPlainArray([1, 2])).toEqual(true)
+    })
+
+    it('should return `false` for non plain arrays', () => {
+      expect(isPlainArray(Object.assign([1, 2], { a: 'b' }))).toEqual(false)
     })
   })
 

--- a/src/core/tests/utils.test.tsx
+++ b/src/core/tests/utils.test.tsx
@@ -258,6 +258,13 @@ describe('core/utils', () => {
       expect(result[1]).toBe(prev[1])
     })
 
+    it('should support objects which are not plain arrays', () => {
+      const prev = Object.assign([1, 2], { a: { b: 'b' }, c: 'c' })
+      const next = Object.assign([1, 2], { a: { b: 'b' }, c: 'c' })
+      const result = replaceEqualDeep(prev, next)
+      expect(result).toBe(next)
+    })
+
     it('should replace all parent objects if some nested value changes', () => {
       const prev = {
         todo: { id: '1', meta: { createdAt: 0 }, state: { done: false } },

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -314,7 +314,7 @@ export function replaceEqualDeep(a: any, b: any): any {
     return a
   }
 
-  const array = Array.isArray(a) && Array.isArray(b)
+  const array = isPlainArray(a) && isPlainArray(b)
 
   if (array || (isPlainObject(a) && isPlainObject(b))) {
     const aSize = array ? a.length : Object.keys(a).length
@@ -353,6 +353,10 @@ export function shallowEqualObjects<T>(a: T, b: T): boolean {
   }
 
   return true
+}
+
+export function isPlainArray(a: any) {
+  return Array.isArray(a) && a.length === Object.keys(a).length
 }
 
 // Copied from: https://github.com/jonschlinkert/is-plain-object

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -355,8 +355,8 @@ export function shallowEqualObjects<T>(a: T, b: T): boolean {
   return true
 }
 
-export function isPlainArray(a: any) {
-  return Array.isArray(a) && a.length === Object.keys(a).length
+export function isPlainArray(value: unknown) {
+  return Array.isArray(value) && value.length === Object.keys(value).length
 }
 
 // Copied from: https://github.com/jonschlinkert/is-plain-object


### PR DESCRIPTION
It turns out that the `replaceDeepEqual` function wasn't returning the intended value for objects that are non-plain arrays.

E.g.

```tsx
const prev = Object.assign([1, 2], { a: { b: 'b' }, c: 'c' })
const next = Object.assign([1, 2], { a: { b: 'b' }, c: 'c' })

replaceDeepEqual(prev, next) // result: [1, 2]
```

This data structure is used in libraries such as [ethers](https://docs.ethers.io/v5/) and their [contract `Result` value](https://docs.ethers.io/v5/api/utils/abi/interface/#Result).

I'm not sure if we should perform structural sharing on these values as they are not really "JSON-compatible" values as mentioned in the [docs](https://react-query.tanstack.com/guides/important-defaults), so I added a change which just checks if the given array is a "plain array", and if it is not, it has changed.