### PR TITLE
fix(persist): introduce in-house synchronous Storage interface

### DIFF
--- a/src/createWebStoragePersister/index.ts
+++ b/src/createWebStoragePersister/index.ts
@@ -5,6 +5,12 @@ import {
   PersistRetryer,
 } from '../persistQueryClient'
 
+interface Storage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+}
+
 interface CreateWebStoragePersisterOptions {
   /** The storage client used for setting and retrieving items from cache.
    * For SSR pass in `undefined`.


### PR DESCRIPTION
### Rationale
Currently RQ has `createWebStoragePersistor` and `createAsyncStoragePersistor` which assumes that non-web platforms can have async storages only, which is not true. React Native has performant synchronous MMKV adapters support, which can't be used with RQ 3 right now directly because of interface incompatibility and `window` check(already fixed in v4).
Related discussion: https://github.com/tannerlinsley/react-query/discussions/3667

### Changes
Introduce own `Storage` interface to make possible using `createWebStoragePersistor` in React Native without TS errors.